### PR TITLE
Support for cmd line arguments, code refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This algorithm is for
 * guided image synthesis (for example, transfer the style between different images)
 
 # Hardware
-* For cuda backend: choose 'speed' if your have at least 4GB graphic memory, and 'memory' otherwise. There is also an opencl backend (thanks to Dionýz Lazar). See "run_trans.lua" and "run_syn.lua" for our reference tests with Titan X, GT750M 2G and Sapphire Radeon R9 280 3G.  
+* For CUDA backend: choose 'speed' if your have at least 4GB graphic memory, and 'memory' otherwise. There is also an opencl backend (thanks to Dionýz Lazar). See "run_trans.lua" and "run_syn.lua" for our reference tests with Titan X, GT750M 2G and Sapphire Radeon R9 280 3G.
 
 
 # Examples
@@ -57,13 +57,13 @@ Pre-trained network:
 We use the the original VGG-19 model. You can find the download script at [Neural Style](https://github.com/jcjohnson/neural-style). The downloaded model and prototxt file MUST be saved in the folder "data/models"
 
 # Un-guided Synthesis
-* Run `qlua run_syn.lua` in a terminal. The algorithm will create a synthesis image of twice the size as the style input image.
+* Run `qlua cnnmrf.lua` in a terminal. Most important parameters are '-style_image' for specifying style input image and '-max_size' for resulting image size.
 * The content/style images are located in the folders "data/content" and "data/style" respectively. Notice by default the content image is the same as the style image; and the content image is only used for initalization (optional). 
 * Results are located in the folder "data/result/freesyn/MRF"
-* Parameters are defined & explained in "run_syn.lua".
+* All parameters are explained in "qlua cnnmrf.lua --help".
 
 # Guided Synthesis
-* Run `qlua run_trans.lua` in a terminal. The algorithm will synthesis using the texture of the style image and the structure of the content image. 
+* Run `qlua run_trans.lua` in a terminal. Most important parameters are '-style_image' for specifying style input image, '-content_image' for specifying content input image and '-max_size' for resulting image size.
 * The content/style images are located in the folders "data/content" and "data/style" respectively. 
 * Results are located in the folder "data/result/trans/MRF"
 * Parameters are defined & explained in "run_trans.lua".

--- a/cnnmrf.lua
+++ b/cnnmrf.lua
@@ -1,0 +1,63 @@
+-- -*- coding: utf-8 -*-
+require 'torch'
+require 'paths'
+
+paths.dofile('mylib/helper.lua')
+
+-----------------------------------------
+-- Parameters
+-----------------------------------------
+
+
+
+cmd = torch.CmdLine()
+
+cmd:option('-content_name', 'potrait1', "The content image located in folder 'data/content'")
+cmd:option('-style_name', 'picasso', "The style image located in folder 'data/style'")
+cmd:option('-ini_method', 'image', "Initial method, set to 'image' to use the content image as the initialization; set to 'random' to use random noise.")
+cmd:option('-type', 'transfer', 'transfer|syn')
+cmd:option('-max_size',384, "Maximum size of the image. Larger image needs more time and memory.")
+cmd:option('-backend','cudnn', "Use cudnn' for CUDA-enabled GPUs or 'clnn' for OpenCL.")
+cmd:option('-mode','speed', "Try 'speed' if you have a GPU with more than 4GB memory, and try 'memory' otherwise. The 'speed' mode is significantly faster (especially for synthesizing high resolutions) at the cost of higher GPU memory. ")
+
+cmd:option('-num_res',3, "Number of resolutions. Notice the lowest resolution image should be larger than the patch size otherwise it won't synthesize.")
+cmd:option('-num_iter',{100, 100, 100}, "Number of iterations for each resolution.")
+cmd:option('-mrf_layers',{12, 21}, "The layers for MRF constraint. Usualy layer 21 alone already gives decent results. Including layer 12 may improve the results but at significantly more computational cost.")
+cmd:option('-mrf_weight',{1e-4, 1e-4}, "Weight for each MRF layer. Higher weights leads to more style faithful results.")
+cmd:option('-mrf_patch_size',{3, 3}, "The patch size for MRF constraint. This value is defined seperately for each MRF layer.")
+cmd:option('-target_num_rotation',0, 'To matching objects of different poses. This value is shared by all MRF layers. The total number of rotational copies is "2 * mrf_num_rotation + 1"')
+cmd:option('-target_num_scale',0, 'To matching objects of different scales. This value is shared by all MRF layers. The total number of scaled copies is "2 * mrf_num_scale + 1"')
+cmd:option('-target_sample_stride',{2, 2}, "Stride to sample mrf on style image. This value is defined seperately for each MRF layer.")
+cmd:option('-mrf_confidence_threshold',{0, 0}, "Threshold for filtering out bad matching. Default value 0 means we keep all matchings. This value is defined seperately for all layers.")
+cmd:option('-source_sample_stride',{2, 2}, "Stride to sample mrf on synthesis image. This value is defined seperately for each MRF layer. This settings is relevant only for syn setting.")
+
+cmd:option('-content_layers',{21}, "The layers for content constraint")
+cmd:option('-content_weight',2e1, "The weight for content constraint. Increasing this value will make the result more content faithful. Decreasing the value will make the method more style faithful. Notice this value should be increase (for example, doubled) if layer 12 is included for MRF constraint.")
+cmd:option('-tv_weight',1e-3, "TV smoothness weight")
+cmd:option('-scaler', 2, "Relative expansion from example to result. This settings is relevant only for syn setting.")
+
+cmd:option('-gpu_chunck_size_1',256, "Size of chunks to split feature maps along the channel dimension. This is to save memory when normalizing the matching score in mrf layers. Use large value if you have large gpu memory. As reference we use 256 for Titan X, and 32 for Geforce GT750M 2G.")
+cmd:option('-gpu_chunck_size_2',16, "Size of chuncks to split feature maps along the y dimension. This is to save memory when normalizing the matching score in mrf layers. Use large value if you have large gpu memory. As reference we use 16 for Titan X, and 2 for Geforce GT750M 2G.")
+
+-- fixed parameters
+cmd:option('-target_step_rotation', math.pi/24)
+cmd:option('-target_step_scale', 1.05)
+cmd:option('-output_folder', 'data/result/trans/MRF/')
+
+cmd:option('-proto_file', 'data/models/VGG_ILSVRC_19_layers_deploy.prototxt')
+cmd:option('-model_file', 'data/models/VGG_ILSVRC_19_layers.caffemodel')
+cmd:option('-gpu', 0, 'Zero-indexed ID of the GPU to use')
+cmd:option('-nCorrection', 25)
+cmd:option('-print_iter', 10)
+cmd:option('-save_iter', 10)
+
+params = cmd:parse(arg)
+
+local wrapper = nil
+if params.type == 'transfer' then
+    wrapper = require 'transfer_CNNMRF_wrapper'
+else
+    wrapper = require 'syn_CNNMRF_wrapper'
+end
+
+wrapper.main(params)

--- a/mylib/helper.lua
+++ b/mylib/helper.lua
@@ -84,17 +84,17 @@ function computeBB(width, height, alpha)
 	local x0 = width / 2
 	local y0 = height / 2
 
-	x1r = x0+(x1-x0)*math.cos(alpha)+(y1-y0)*math.sin(alpha)
-	y1r = y0-(x1-x0)*math.sin(alpha)+(y1-y0)*math.cos(alpha)
+	local x1r = x0+(x1-x0)*math.cos(alpha)+(y1-y0)*math.sin(alpha)
+	local y1r = y0-(x1-x0)*math.sin(alpha)+(y1-y0)*math.cos(alpha)
 
-	x2r = x0+(x2-x0)*math.cos(alpha)+(y2-y0)*math.sin(alpha)
-	y2r = y0-(x2-x0)*math.sin(alpha)+(y2-y0)*math.cos(alpha)
+	local x2r = x0+(x2-x0)*math.cos(alpha)+(y2-y0)*math.sin(alpha)
+	local y2r = y0-(x2-x0)*math.sin(alpha)+(y2-y0)*math.cos(alpha)
 
-	x3r = x0+(x3-x0)*math.cos(alpha)+(y3-y0)*math.sin(alpha)
-	y3r = y0-(x3-x0)*math.sin(alpha)+(y3-y0)*math.cos(alpha)
+	local x3r = x0+(x3-x0)*math.cos(alpha)+(y3-y0)*math.sin(alpha)
+	local y3r = y0-(x3-x0)*math.sin(alpha)+(y3-y0)*math.cos(alpha)
 
-	x4r = x0+(x4-x0)*math.cos(alpha)+(y4-y0)*math.sin(alpha)
-	y4r = y0-(x4-x0)*math.sin(alpha)+(y4-y0)*math.cos(alpha)
+	local x4r = x0+(x4-x0)*math.cos(alpha)+(y4-y0)*math.sin(alpha)
+	local y4r = y0-(x4-x0)*math.sin(alpha)+(y4-y0)*math.cos(alpha)
 
 	-- print(x1r .. ' ' .. y1r .. ' ' .. x2r .. ' ' .. y2r .. ' ' .. x3r .. ' ' .. y3r .. ' ' .. x4r .. ' ' .. y4r)
 	if alpha > 0 then
@@ -139,7 +139,7 @@ function computeBB(width, height, alpha)
 end
 
 function computegrid(width, height, block_size, block_stride, flag_all)
-	coord_block_y = torch.range(1, height - block_size + 1, block_stride) 
+	local coord_block_y = torch.range(1, height - block_size + 1, block_stride)
 	if flag_all == 1 then
 		if coord_block_y[#coord_block_y] < height - block_size + 1 then
 		  local tail = torch.Tensor(1)
@@ -147,7 +147,7 @@ function computegrid(width, height, block_size, block_stride, flag_all)
 		  coord_block_y = torch.cat(coord_block_y, tail)
 		end
 	end
-	coord_block_x = torch.range(1, width - block_size + 1, block_stride) 
+	local coord_block_x = torch.range(1, width - block_size + 1, block_stride)
 	if flag_all == 1 then
 		if coord_block_x[#coord_block_x] < width - block_size + 1 then
 		  local tail = torch.Tensor(1)
@@ -156,4 +156,30 @@ function computegrid(width, height, block_size, block_stride, flag_all)
 		end
 	end
 	return coord_block_x, coord_block_y
+end
+
+function preprocess(img)
+	local mean_pixel = torch.Tensor({103.939, 116.779, 123.68})
+	local perm = torch.LongTensor{3, 2, 1}
+	img = img:index(1, perm):mul(256.0)
+	mean_pixel = mean_pixel:view(3, 1, 1):expandAs(img)
+	img:add(-1, mean_pixel)
+	return img
+end
+
+-- Undo the above preprocessing.
+function deprocess(img)
+	local mean_pixel = torch.Tensor({103.939, 116.779, 123.68})
+	mean_pixel = mean_pixel:view(3, 1, 1):expandAs(img)
+	img = img + mean_pixel:float()
+	local perm = torch.LongTensor{3, 2, 1}
+	img = img:index(1, perm):div(256.0)
+	return img
+end
+
+function run_tests(run_type, list_params)
+	local wrapper = run_type
+    for i_test = 1, #list_params do
+        wrapper.run_test(table.unpack(list_params[i_test]))
+    end
 end

--- a/mylib/mrf.lua
+++ b/mylib/mrf.lua
@@ -179,7 +179,7 @@ function MRFMM:updateGradInput(input, gradOutput)
   end
 
   -- local timer_AFT = torch.Timer()
-  max_response, max_id = torch.max(self.response, 1)
+  local max_response, max_id = torch.max(self.response, 1)
   -- local t_aft = timer_AFT:time().real
 
   -- local t_match = timer_MATCH:time().real

--- a/run_syn.lua
+++ b/run_syn.lua
@@ -1,17 +1,8 @@
-require 'torch'
-require 'nn'
-require 'image'
 require 'paths'
-
-paths.dofile('mylib/myoptimizer.lua')
-paths.dofile('mylib/tv.lua')
-paths.dofile('mylib/mrf.lua')
 paths.dofile('mylib/helper.lua')
 
-syn_CNNMRF_wrapper = require 'syn_CNNMRF_wrapper'
-
 -----------------------------------------
--- parameters:
+-- Parameters:
 -----------------------------------------
 -- content_name: the content image located in folder "data/content". Notice for free synthesis this image is only used for initialization (and only when "ini_method" is set to "image")
 -- style_name: the style image located in folder "data/style" 
@@ -23,11 +14,11 @@ syn_CNNMRF_wrapper = require 'syn_CNNMRF_wrapper'
 
 -- mrf_layers: the layers for MRF constraint. Usualy layer 21 alone already gives decent results. Including layer 12 may improve the results but at significantly more computational cost.
 -- mrf_weight: weight for each MRF layer. Default value 1e-4. For free texture synthesis it can be seen as the "learning rate" in gradient decent.
--- mrf_patch_size: the patch size for MRF constraint. By default value 3. This value is defined seperately for each MRF layer.
+-- mrf_patch_size: the patch size for MRF constraint. Default value 3. This value is defined seperately for each MRF layer.
 -- mrf_num_rotation: To matching objects of different poses. Default value 0. This value is shared by all MRF layers. The total number of rotatoinal copies is "2 * mrf_num_rotation + 1"
 -- mrf_num_scale: To matching objects of different scales. Default value 0. This value is shared by all MRF layers. The total number of scaled copies is "2 * mrf_num_scale + 1"
--- mrf_sample_stride: stride to sample mrf on style image. Default value 2. This value is defined seperately for each MRF layer. This value is defined for each MRF layer.
--- mrf_synthesis_stride: stride to sample mrf on synthesis image. Default value 2. This value is defined seperately for each MRF layer. This value is defined for each MRF layer.
+-- mrf_sample_stride: stride to sample mrf on style image. Default value 2. This value is defined seperately for each MRF layer.
+-- mrf_synthesis_stride: stride to sample mrf on synthesis image. Default value 2. This value is defined seperately for each MRF layer.
 -- mrf_confidence_threshold: threshold for filtering out bad matching. Default value 0 -- means we keep all matchings. This value is defined seperately for all layers.
 
 -- tv_weight: TV smoothness weight. Default value 1e-3.
@@ -55,10 +46,4 @@ local list_params = {
                         {'2', '2', 'random', 384, 2, 3, {100, 100, 100}, {12, 21}, {1e-4, 1e-4}, {3, 3}, 1, 1, {2, 2}, {2, 2}, {0, 0}, 1e-3, 'memory', 256, 16, 'cudnn'},
                     }    
 
-for i_test = 1, #list_params do
-    local state = syn_CNNMRF_wrapper.state(list_params[i_test][1], list_params[i_test][2], list_params[i_test][3], list_params[i_test][4], list_params[i_test][5], list_params[i_test][6], list_params[i_test][7], list_params[i_test][8], list_params[i_test][9], list_params[i_test][10], list_params[i_test][11], list_params[i_test][12], list_params[i_test][13], list_params[i_test][14], list_params[i_test][15], list_params[i_test][16], list_params[i_test][17], list_params[i_test][18], list_params[i_test][19], list_params[i_test][20], list_params[i_test][21])
-    collectgarbage()
-end
-
-
-do return end
+run_tests(require 'syn_CNNMRF_wrapper', list_params)

--- a/run_trans.lua
+++ b/run_trans.lua
@@ -1,18 +1,8 @@
-require 'torch'
-require 'nn'
-require 'image'
 require 'paths'
-
-paths.dofile('mylib/myoptimizer.lua')
-paths.dofile('mylib/tv.lua')
-paths.dofile('mylib/content.lua')
-paths.dofile('mylib/mrf.lua')
 paths.dofile('mylib/helper.lua')
 
-transfer_CNNMRF_wrapper = require 'transfer_CNNMRF_wrapper'
-
 -----------------------------------------
--- Parameters
+-- Parameters:
 -----------------------------------------
 -- content_name: the content image located in folder "data/content"
 -- style_name: the style image located in folder "data/style" 
@@ -77,12 +67,6 @@ local list_params = {
                     {'0', '0', 'image', 384, 3, {100, 100, 100}, {12, 21}, {1e-4, 1e-4}, {3, 3}, 3, 3, {2, 2}, {2, 2}, {0, 0}, {23}, 2e1, 1e-3, 'speed', 256, 16, 'cudnn'},
                     {'1', '1', 'image', 384, 3, {100, 100, 100}, {12, 21}, {1e-4, 1e-4}, {3, 3}, 3, 3, {2, 2}, {2, 2}, {0, 0}, {23}, 0.5e1, 1e-3, 'speed', 256, 16, 'cudnn'},
                     {'potrait1', 'picasso', 'image', 384, 3, {100, 100, 100}, {12, 21}, {1e-4, 1e-4}, {3, 3}, 1, 1, {2, 2}, {2, 2}, {0, 0}, {23}, 2e1, 1e-3, 'memory', 256, 16, 'clnn'},
-                    }
+}
 
-for i_test = 1, #list_params do
-    local state = transfer_CNNMRF_wrapper.state(list_params[i_test][1], list_params[i_test][2], list_params[i_test][3], list_params[i_test][4], list_params[i_test][5], list_params[i_test][6], list_params[i_test][7], list_params[i_test][8], list_params[i_test][9], list_params[i_test][10], list_params[i_test][11], list_params[i_test][12], list_params[i_test][13], list_params[i_test][14], list_params[i_test][15], list_params[i_test][16], list_params[i_test][17], list_params[i_test][18], list_params[i_test][19], list_params[i_test][20], list_params[i_test][21])
-    collectgarbage()
-end
-
-
-do return end
+run_tests(require 'transfer_CNNMRF_wrapper', list_params)

--- a/syn_CNNMRF_wrapper.lua
+++ b/syn_CNNMRF_wrapper.lua
@@ -12,6 +12,11 @@ paths.dofile('mylib/helper.lua')
 torch.setdefaulttensortype('torch.FloatTensor') -- float as default tensor type
 
 local function main(params)
+  os.execute('mkdir data/result/')
+  os.execute('mkdir data/result/freesyn/')
+  os.execute('mkdir data/result/freesyn/MRF/')
+  os.execute(string.format('mkdir %s', params.output_folder))
+
   local net = nn.Sequential()
   local i_net_layer = 0
   local num_calls = 0
@@ -239,7 +244,7 @@ local function main(params)
     local disp = deprocess(input_image:float())
     disp = image.minmax{tensor=disp, min=0, max=1}
     disp = image.scale(disp, render_width, render_height, 'bilinear')
-    local filename = string.format('%s/res_%d_%f.jpg', params.output_folder, cur_res, t)
+    local filename = string.format('%s/res_%d_%d.jpg', params.output_folder, cur_res, t)
     image.save(filename, disp)
     end
   end
@@ -478,10 +483,6 @@ local function run_test(content_name, style_name, ini_method, max_size, scaler, 
   params.gpu_chunck_size_2 = 2
 
   params.output_folder = string.format('data/result/freesyn/MRF/%s_TO_%s', params.content_name, params.style_name)
-  os.execute('mkdir data/result/')
-  os.execute('mkdir data/result/freesyn/')
-  os.execute('mkdir data/result/freesyn/MRF/')
-  os.execute(string.format('mkdir %s', params.output_folder))
 
   main(params)
 

--- a/syn_CNNMRF_wrapper.lua
+++ b/syn_CNNMRF_wrapper.lua
@@ -4,9 +4,430 @@ require 'image'
 require 'paths'
 require 'loadcaffe'
 
+paths.dofile('mylib/myoptimizer.lua')
+paths.dofile('mylib/tv.lua')
+paths.dofile('mylib/mrf.lua')
+paths.dofile('mylib/helper.lua')
+
 torch.setdefaulttensortype('torch.FloatTensor') -- float as default tensor type
 
+local function main(params)
+  local net = nn.Sequential()
+  local i_net_layer = 0
+  local num_calls = 0
+  local next_mrf_idx = 1
+  local mrf_losses = {}
+  local mrf_layers = {}
+  local i_mrf_layer = 0
+  local input_image
+  local output_image
+  local cur_res
+  local mrf_layers_pretrained = params.mrf_layers
+
+  -----------------------------------------------------------------------------------
+  -- read images
+  -----------------------------------------------------------------------------------
+  local source_image = image.load(string.format('data/content/%s.jpg', params.content_name), 3)
+  local target_image = image.load(string.format('data/style/%s.jpg', params.style_name), 3)
+
+  source_image = image.scale(source_image, params.max_size, 'bilinear')
+  target_image = image.scale(target_image, math.floor(params.max_size / params.scaler), 'bilinear')
+
+  local render_height = source_image:size()[2]
+  local render_width = source_image:size()[3]
+  local source_image_caffe = preprocess(source_image):float()
+  local target_image_caffe = preprocess(target_image):float()
+
+  local pyramid_source_image_caffe = {}
+  for i_res = 1, params.num_res do
+    pyramid_source_image_caffe[i_res] = image.scale(source_image_caffe, math.ceil(source_image:size()[3] * math.pow(0.5, params.num_res - i_res)), math.ceil(source_image:size()[2] * math.pow(0.5, params.num_res - i_res)), 'bilinear')
+  end
+
+  local pyramid_target_image_caffe = {}
+  for i_res = 1, params.num_res do
+    pyramid_target_image_caffe[i_res] = image.scale(target_image_caffe, math.ceil(target_image:size()[3] * math.pow(0.5, params.num_res - i_res)), math.ceil(target_image:size()[2] * math.pow(0.5, params.num_res - i_res)), 'bilinear')
+  end
+
+  -- --------------------------------------------------------------------------------------------------------
+  -- -- local function for adding a mrf layer, with image rotation andn scaling
+  -- --------------------------------------------------------------------------------------------------------
+  local function add_mrf()
+      local mrf_module = nn.MRFMM()
+      i_mrf_layer = i_mrf_layer + 1
+      i_net_layer = i_net_layer + 1
+      next_mrf_idx = next_mrf_idx + 1
+      if params.gpu >= 0 then
+        if params.backend == 'cudnn' then
+          mrf_module:cuda()
+        else
+          mrf_module:cl()
+        end
+      end
+      net:add(mrf_module)
+      table.insert(mrf_losses, mrf_module)
+      table.insert(mrf_layers, i_mrf_layer, i_net_layer)
+      return true
+  end
+
+  local function build_mrf(id_mrf)
+    --------------------------------------------------------
+    -- deal with target
+    --------------------------------------------------------
+    local target_images_caffe = {}
+    for i_r = -params.target_num_rotation, params.target_num_rotation do
+      local alpha = params.target_step_rotation * i_r
+      local min_x, min_y, max_x, max_y = computeBB(pyramid_target_image_caffe[cur_res]:size()[3], pyramid_target_image_caffe[cur_res]:size()[2], alpha)
+      local target_image_rt_caffe = image.rotate(pyramid_target_image_caffe[cur_res], alpha, 'bilinear')
+      target_image_rt_caffe = target_image_rt_caffe[{{1, target_image_rt_caffe:size()[1]}, {min_y, max_y}, {min_x, max_x}}]
+
+      for i_s = -params.target_num_scale, params.target_num_scale do
+        local max_sz = math.floor(math.max(target_image_rt_caffe:size()[2], target_image_rt_caffe:size()[3]) * torch.pow(params.target_step_scale, i_s))
+        local target_image_rt_s_caffe = image.scale(target_image_rt_caffe, max_sz, 'bilinear')
+        if params.backend == 'cudnn' then
+          target_image_rt_s_caffe = target_image_rt_s_caffe:cuda()
+        else
+          target_image_rt_s_caffe = target_image_rt_s_caffe:cl()
+        end
+        table.insert(target_images_caffe, target_image_rt_s_caffe)
+      end
+    end
+
+    -- compute the coordinates on the pixel layer
+    local target_x
+    local target_y
+    local target_x_per_image = {}
+    local target_y_per_image = {}
+    local target_imageid
+    -- print('*****************************************************')
+    -- print(string.format('build target mrf'));
+    -- print('*****************************************************')
+    for i_image = 1, #target_images_caffe do
+      -- print(string.format('image %d, ', i_image))
+      net:forward(target_images_caffe[i_image])
+      local target_feature_map = net:get(mrf_layers[id_mrf] - 1).output:float()
+
+      if params.mrf_patch_size[id_mrf] > target_feature_map:size()[2] or params.mrf_patch_size[id_mrf] > target_feature_map:size()[3] then
+        print('target_images is not big enough for patch')
+        print('target_images size: ')
+        print(target_feature_map:size())
+        print('patch size: ')
+        print(params.mrf_patch_size[id_mrf])
+        do return end
+      end
+      local target_x_, target_y_ = drill_computeMRFfull(target_feature_map,  params.mrf_patch_size[id_mrf], params.target_sample_stride[id_mrf], -1)
+
+
+      local x = torch.Tensor(target_x_:nElement() * target_y_:nElement())
+      local y = torch.Tensor(target_x_:nElement() * target_y_:nElement())
+      local target_imageid_ = torch.Tensor(target_x_:nElement() * target_y_:nElement()):fill(i_image)
+      local count = 1
+      for i_row = 1, target_y_:nElement() do
+        for i_col = 1, target_x_:nElement() do
+          x[count] = target_x_[i_col]
+          y[count] = target_y_[i_row]
+          count = count + 1
+        end
+      end
+      if i_image == 1 then
+        target_x = x:clone()
+        target_y = y:clone()
+        target_imageid = target_imageid_:clone()
+      else
+        target_x = torch.cat(target_x, x, 1)
+        target_y = torch.cat(target_y, y, 1)
+        target_imageid = torch.cat(target_imageid, target_imageid_, 1)
+      end
+      table.insert(target_x_per_image, x)
+      table.insert(target_y_per_image, y)
+    end -- end for i_image = 1, #target_images do
+
+    -- print('*****************************************************')
+    -- print(string.format('collect mrf'));
+    -- print('*****************************************************')
+
+    local num_channel_mrf = net:get(mrf_layers[id_mrf] - 1).output:size()[1]
+    local target_mrf = torch.Tensor(target_x:nElement(), num_channel_mrf * params.mrf_patch_size[id_mrf] * params.mrf_patch_size[id_mrf])
+    local tensor_target_mrf = torch.Tensor(target_x:nElement(), num_channel_mrf, params.mrf_patch_size[id_mrf], params.mrf_patch_size[id_mrf])
+    local count_mrf = 1
+    for i_image = 1, #target_images_caffe do
+      -- print(string.format('image %d, ', i_image));
+      net:forward(target_images_caffe[i_image])
+      -- sample mrf on mrf_layers
+      local tensor_target_mrf_, target_mrf_ = sampleMRFAndTensorfromLocation2(target_x_per_image[i_image], target_y_per_image[i_image], net:get(mrf_layers[id_mrf] - 1).output:float(), params.mrf_patch_size[id_mrf])
+      target_mrf[{{count_mrf, count_mrf + target_mrf_:size()[1] - 1}, {1, target_mrf:size()[2]}}] = target_mrf_:clone()
+      tensor_target_mrf[{{count_mrf, count_mrf + target_mrf_:size()[1] - 1}, {1, tensor_target_mrf:size()[2]}, {1, tensor_target_mrf:size()[3]}, {1, tensor_target_mrf:size()[4]}}] = tensor_target_mrf_:clone()
+      count_mrf = count_mrf + target_mrf_:size()[1]
+      tensor_target_mrf_ = nil
+      target_mrf_ = nil
+      collectgarbage()
+    end --for i_image = 1, #target_images do
+    local target_mrfnorm = torch.sqrt(torch.sum(torch.cmul(target_mrf, target_mrf), 2)):resize(target_mrf:size()[1], 1, 1)
+
+    --------------------------------------------------------
+    -- process source
+    --------------------------------------------------------
+    -- print('*****************************************************')
+    -- print(string.format('process source image'));
+    -- print('*****************************************************')
+    if params.backend == 'cudnn' then
+      net:forward(pyramid_source_image_caffe[cur_res]:cuda())
+    else
+      net:forward(pyramid_source_image_caffe[cur_res]:cl())
+    end
+    local source_feature_map = net:get(mrf_layers[id_mrf] - 1).output:float()
+    if params.mrf_patch_size[id_mrf] > source_feature_map:size()[2] or params.mrf_patch_size[id_mrf] > source_feature_map:size()[3] then
+      print('source_image_caffe is not big enough for patch')
+      print('source_image_caffe size: ')
+      print(source_feature_map:size())
+      print('patch size: ')
+      print(params.mrf_patch_size[id_mrf])
+      do return end
+    end
+    local source_xgrid, source_ygrid = drill_computeMRFfull(source_feature_map:float(), params.mrf_patch_size[id_mrf], params.source_sample_stride[id_mrf], -1)
+    local source_x = torch.Tensor(source_xgrid:nElement() * source_ygrid:nElement())
+    local source_y = torch.Tensor(source_xgrid:nElement() * source_ygrid:nElement())
+    local count = 1
+    for i_row = 1, source_ygrid:nElement() do
+      for i_col = 1, source_xgrid:nElement() do
+        source_x[count] = source_xgrid[i_col]
+        source_y[count] = source_ygrid[i_row]
+        count = count + 1
+      end
+    end
+    -- local tensor_target_mrfnorm = torch.repeatTensor(target_mrfnorm:float(), 1, net:get(mrf_layers[id_mrf] - 1).output:size()[2] - (params.mrf_patch_size[id_mrf] - 1), net:get(mrf_layers[id_mrf] - 1).output:size()[3] - (params.mrf_patch_size[id_mrf] - 1))
+
+    -- print('*****************************************************')
+    -- print(string.format('call layer implemetation'));
+    -- print('*****************************************************')
+    local nInputPlane = target_mrf:size()[2] / (params.mrf_patch_size[id_mrf] * params.mrf_patch_size[id_mrf])
+    local nOutputPlane = target_mrf:size()[1]
+    local kW = params.mrf_patch_size[id_mrf]
+    local kH = params.mrf_patch_size[id_mrf]
+    local dW = 1
+    local dH = 1
+    local input_size = source_feature_map:size()
+
+    local source_xgrid_, source_ygrid_ = drill_computeMRFfull(source_feature_map:float(), params.mrf_patch_size[id_mrf], 1, -1)
+    local response_size = torch.LongStorage(3)
+    response_size[1] = nOutputPlane
+    response_size[2] = source_ygrid_:nElement()
+    response_size[3] = source_xgrid_:nElement()
+    net:get(mrf_layers[id_mrf]):implement(params.mode, target_mrf, tensor_target_mrf, target_mrfnorm, source_x, source_y, input_size, response_size, nInputPlane, nOutputPlane, kW, kH, 1, 1, params.mrf_confidence_threshold[id_mrf], params.mrf_weight[id_mrf], params.gpu_chunck_size_1, params.gpu_chunck_size_2, params.backend)
+    target_mrf = nil
+    tensor_target_mrf = nil
+    source_feature_map = nil
+    collectgarbage()
+  end
+
+  --------------------------------------------------------------------------------------------------------
+  -- local function for printing inter-mediate result
+  --------------------------------------------------------------------------------------------------------
+  local function maybe_print(t, loss)
+    local verbose = (params.print_iter > 0 and t % params.print_iter == 0)
+    if verbose then
+        print(string.format('Iteration %d, %d', t, params.num_iter[cur_res]))
+     end
+  end
+
+  --------------------------------------------------------------------------------------------------------
+  -- local function for saving inter-mediate result
+  --------------------------------------------------------------------------------------------------------
+  local function maybe_save(t)
+    local should_save = params.save_iter > 0 and t % params.save_iter == 0
+    should_save = should_save or t == params.num_iter
+    if should_save then
+    local disp = deprocess(input_image:float())
+    disp = image.minmax{tensor=disp, min=0, max=1}
+    disp = image.scale(disp, render_width, render_height, 'bilinear')
+    local filename = string.format('%s/res_%d_%f.jpg', params.output_folder, cur_res, t)
+    image.save(filename, disp)
+    end
+  end
+
+  --------------------------------------------------------------------------------------------------------
+  -- local function for computing energy
+  --------------------------------------------------------------------------------------------------------
+  local function feval(x)
+    num_calls = num_calls + 1
+    net:forward(x)
+    local grad = net:backward(x, dy)
+    local loss = 0
+    collectgarbage()
+
+    maybe_print(num_calls, loss)
+    maybe_save(num_calls)
+
+    -- optim.lbfgs expects a vector for gradients
+    return loss, grad:view(grad:nElement())
+  end
+
+  -------------------------------------------------------------------------------
+  -- initialize network
+  -------------------------------------------------------------------------------
+  if params.gpu >= 0 then
+    if params.backend == 'cudnn' then
+      require 'cutorch'
+      require 'cunn'
+      cutorch.setDevice(params.gpu + 1)
+    else
+      require 'cltorch'
+      require 'clnn'
+      cltorch.setDevice(params.gpu + 1)
+    end
+  else
+    params.backend = 'nn-cpu'
+  end
+
+  if params.backend == 'cudnn' then
+    require 'cudnn'
+  end
+
+  local loadcaffe_backend = params.backend
+  if params.backend == 'clnn' then
+    loadcaffe_backend = 'nn'
+  end
+  local cnn = loadcaffe.load(params.proto_file, params.model_file, loadcaffe_backend):float()
+  if params.gpu >= 0 then
+    if params.backend == 'cudnn' then
+      cnn:cuda()
+    else
+      cnn:cl()
+    end
+  end
+  print('cnn succesfully loaded')
+
+  for i_res = 1, params.num_res do
+    local timer = torch.Timer()
+
+    cur_res = i_res
+    num_calls = 0
+    local optim_state = {
+      maxIter = params.num_iter[i_res],
+      nCorrection = params.nCorrection,
+      verbose=true,
+      tolX = 0,
+      tolFun = 0,
+    }
+
+    -- initialize image and target
+    if i_res == 1 then
+
+      if params.ini_method == 'random' then
+        input_image = torch.randn(pyramid_source_image_caffe[i_res]:size()):float():mul(0.001)
+      elseif params.ini_method == 'image' then
+        input_image = pyramid_source_image_caffe[i_res]:clone():float()
+      else
+        error('Invalid init type')
+      end
+      if params.backend == 'cudnn' then
+        input_image = input_image:cuda()
+      else
+        input_image = input_image:cl()
+      end
+
+      -----------------------------------------------------
+      -- add a tv layer
+      -----------------------------------------------------
+      if params.tv_weight > 0 then
+        local tv_mod = nn.TVLoss(params.tv_weight):float()
+        if params.gpu >= 0 then
+          if params.backend == 'cudnn' then
+            tv_mod:cuda()
+          else
+            tv_mod:cl()
+          end
+        end
+        i_net_layer = i_net_layer + 1
+        net:add(tv_mod)
+      end
+
+      for i = 1, #cnn do
+        if next_mrf_idx <= #mrf_layers_pretrained then
+          local layer = cnn:get(i)
+
+          i_net_layer = i_net_layer + 1
+          net:add(layer)
+
+          -- -- add mrfstatsyn layer
+          if i == mrf_layers_pretrained[next_mrf_idx] then
+            if add_mrf() == false then
+              print('build network failed: adding mrf layer failed')
+              do return end
+            end
+          end
+
+        end
+      end -- for i = 1, #cnn do
+
+      cnn = nil
+      collectgarbage()
+
+      print(net)
+
+
+      print('mrf_layers: ')
+      for i = 1, #mrf_layers do
+        print(mrf_layers[i])
+      end
+
+      print('network has been built.')
+    else
+      input_image = image.scale(input_image:float(), pyramid_source_image_caffe[i_res]:size()[3], pyramid_source_image_caffe[i_res]:size()[2], 'bilinear'):clone()
+      if params.backend == 'cudnn' then
+        input_image = input_image:cuda()
+      else
+        input_image = input_image:cl()
+      end
+
+    end
+
+    print('*****************************************************')
+    print(string.format('Synthesis started at resolution ', cur_res))
+    print('*****************************************************')
+
+    print('Implementing mrf layers ...')
+    for i = 1, #mrf_layers do
+      if build_mrf(i) == false then
+        print('build_mrf failed')
+        do return end
+      end
+    end
+
+    local mask = torch.Tensor(input_image:size()):fill(1)
+    if params.backend == 'cudnn' then
+      mask = mask:cuda()
+    else
+      mask = mask:cl()
+    end
+
+    y = net:forward(input_image)
+    dy = input_image.new(#y):zero()
+
+    -- do optimizatoin
+    local x, losses = mylbfgs(feval, input_image, optim_state, nil, mask)
+
+    local t = timer:time().real
+    print(string.format('Synthesis finished at resolution %d, %f seconds', cur_res, t))
+  end
+
+  net = nil
+  source_image = nil
+  target_image = nil
+  pyramid_source_image_caffe = nil
+  pyramid_target_image_caffe = nil
+  input_image = nil
+  output_image = nil
+  mrf_losses = nil
+  mrf_layers = nil
+  optim_state = nil
+  collectgarbage()
+  collectgarbage()
+
+end -- end of main
+
+
 local function run_test(content_name, style_name, ini_method, max_size, scaler, num_res, num_iter, mrf_layers, mrf_weight, mrf_patch_size, mrf_num_rotation, mrf_num_scale, mrf_sample_stride, mrf_synthesis_stride, mrf_confidence_threshold, tv_weight, mode,  gpu_chunck_size_1, gpu_chunck_size_2, backend)
+
   -- local clock = os.clock
   -- function sleep(n)  -- seconds
   --   local t0 = clock()
@@ -17,12 +438,12 @@ local function run_test(content_name, style_name, ini_method, max_size, scaler, 
 
   local flag_state = 1
 
-  local cmd = torch.CmdLine()
-  local params = cmd:parse(arg)
+  local params = {}
 
   -- externally set paramters
   params.content_name = content_name
   params.style_name = style_name
+  --print(backend)
   params.ini_method = ini_method  
   params.max_size = max_size or 384
   params.scaler = scaler or 2
@@ -46,10 +467,7 @@ local function run_test(content_name, style_name, ini_method, max_size, scaler, 
   -- fixed parameters
   params.target_step_rotation = math.pi/24
   params.target_step_scale = 1.05
-  os.execute('mkdir ' .. 'data/result/')
-  os.execute('mkdir ' .. 'data/result/freesyn/')
-  os.execute('mkdir ' .. 'data/result/freesyn/MRF/')  
-  params.output_folder = 'data/result/freesyn/MRF/' .. params.content_name .. '_TO_' .. params.style_name
+
   params.proto_file = 'data/models/VGG_ILSVRC_19_layers_deploy.prototxt'
   params.model_file = 'data/models/VGG_ILSVRC_19_layers.caffemodel'
   params.gpu = 0
@@ -59,452 +477,21 @@ local function run_test(content_name, style_name, ini_method, max_size, scaler, 
   params.gpu_chunck_size_1 = 32
   params.gpu_chunck_size_2 = 2
 
-  os.execute('mkdir ' .. params.output_folder)
+  params.output_folder = string.format('data/result/freesyn/MRF/%s_TO_%s', params.content_name, params.style_name)
+  os.execute('mkdir data/result/')
+  os.execute('mkdir data/result/freesyn/')
+  os.execute('mkdir data/result/freesyn/MRF/')
+  os.execute(string.format('mkdir %s', params.output_folder))
 
-  local function main(params)
-    local net = nn.Sequential()
-    local i_net_layer = 0
-    local num_calls = 0
-    local next_mrf_idx = 1
-    local mrf_losses = {}
-    local mrf_layers = {}
-    local i_mrf_layer = 0
-    local input_image
-    local output_image
-    local cur_res
-    local mrf_layers_pretrained = params.mrf_layers
-
-    -----------------------------------------------------------------------------------
-    -- read images
-    -----------------------------------------------------------------------------------
-    local source_image = image.load('data/content/' .. params.content_name  .. '.jpg', 3)
-    local target_image = image.load('data/style/' .. params.style_name  .. '.jpg', 3)
-
-    source_image = image.scale(source_image, params.max_size, 'bilinear')
-    target_image = image.scale(target_image, math.floor(params.max_size / params.scaler), 'bilinear')
-
-    local render_height = source_image:size()[2]
-    local render_width = source_image:size()[3]
-    source_image_caffe = preprocess(source_image):float()
-    target_image_caffe = preprocess(target_image):float()
-
-    local pyramid_source_image_caffe = {}
-    for i_res = 1, params.num_res do
-      pyramid_source_image_caffe[i_res] = image.scale(source_image_caffe, math.ceil(source_image:size()[3] * math.pow(0.5, params.num_res - i_res)), math.ceil(source_image:size()[2] * math.pow(0.5, params.num_res - i_res)), 'bilinear')
-    end
-
-    local pyramid_target_image_caffe = {}
-    for i_res = 1, params.num_res do
-      pyramid_target_image_caffe[i_res] = image.scale(target_image_caffe, math.ceil(target_image:size()[3] * math.pow(0.5, params.num_res - i_res)), math.ceil(target_image:size()[2] * math.pow(0.5, params.num_res - i_res)), 'bilinear')
-    end
-
-    -- --------------------------------------------------------------------------------------------------------
-    -- -- local function for adding a mrf layer, with image rotation andn scaling
-    -- --------------------------------------------------------------------------------------------------------
-    local function add_mrf()
-        local mrf_module = nn.MRFMM()
-        i_mrf_layer = i_mrf_layer + 1
-        i_net_layer = i_net_layer + 1
-        next_mrf_idx = next_mrf_idx + 1 
-        if params.gpu >= 0 then
-          if params.backend == 'cudnn' then
-            mrf_module:cuda()
-          else
-            mrf_module:cl()
-          end
-        end
-        net:add(mrf_module)
-        table.insert(mrf_losses, mrf_module)
-        table.insert(mrf_layers, i_mrf_layer, i_net_layer)
-        return true
-    end
-
-    local function build_mrf(id_mrf)
-      --------------------------------------------------------
-      -- deal with target
-      --------------------------------------------------------
-      target_images_caffe = {}
-      for i_r = -params.target_num_rotation, params.target_num_rotation do
-        local alpha = params.target_step_rotation * i_r 
-        local min_x, min_y, max_x, max_y = computeBB(pyramid_target_image_caffe[cur_res]:size()[3], pyramid_target_image_caffe[cur_res]:size()[2], alpha)
-        local target_image_rt_caffe = image.rotate(pyramid_target_image_caffe[cur_res], alpha, 'bilinear')
-        target_image_rt_caffe = target_image_rt_caffe[{{1, target_image_rt_caffe:size()[1]}, {min_y, max_y}, {min_x, max_x}}]
-
-        for i_s = -params.target_num_scale, params.target_num_scale do  
-          local max_sz = math.floor(math.max(target_image_rt_caffe:size()[2], target_image_rt_caffe:size()[3]) * torch.pow(params.target_step_scale, i_s))
-          local target_image_rt_s_caffe = image.scale(target_image_rt_caffe, max_sz, 'bilinear')
-          if params.backend == 'cudnn' then
-            target_image_rt_s_caffe = target_image_rt_s_caffe:cuda()
-          else
-            target_image_rt_s_caffe = target_image_rt_s_caffe:cl()
-          end
-          table.insert(target_images_caffe, target_image_rt_s_caffe)
-        end
-      end
-
-      -- compute the coordinates on the pixel layer
-      local target_x
-      local target_y
-      local target_x_per_image = {}
-      local target_y_per_image = {}
-      local target_imageid
-      -- print('*****************************************************')
-      -- print(string.format('build target mrf'));
-      -- print('*****************************************************')   
-      for i_image = 1, #target_images_caffe do
-        -- print(string.format('image %d, ', i_image))
-        net:forward(target_images_caffe[i_image])
-        local target_feature_map = net:get(mrf_layers[id_mrf] - 1).output:float()
-
-        if params.mrf_patch_size[id_mrf] > target_feature_map:size()[2] or params.mrf_patch_size[id_mrf] > target_feature_map:size()[3] then 
-          print('target_images is not big enough for patch')
-          print('target_images size: ')
-          print(target_feature_map:size())
-          print('patch size: ')
-          print(params.mrf_patch_size[id_mrf])
-          do return end
-        end 
-        local target_x_, target_y_ = drill_computeMRFfull(target_feature_map,  params.mrf_patch_size[id_mrf], params.target_sample_stride[id_mrf], -1) 
-
-
-        local x = torch.Tensor(target_x_:nElement() * target_y_:nElement())
-        local y = torch.Tensor(target_x_:nElement() * target_y_:nElement())
-        local target_imageid_ = torch.Tensor(target_x_:nElement() * target_y_:nElement()):fill(i_image)
-        local count = 1
-        for i_row = 1, target_y_:nElement() do
-          for i_col = 1, target_x_:nElement() do
-            x[count] = target_x_[i_col]
-            y[count] = target_y_[i_row]
-            count = count + 1
-          end
-        end
-        if i_image == 1 then
-          target_x = x:clone()
-          target_y = y:clone()
-          target_imageid = target_imageid_:clone()
-        else
-          target_x = torch.cat(target_x, x, 1)
-          target_y = torch.cat(target_y, y, 1)
-          target_imageid = torch.cat(target_imageid, target_imageid_, 1)
-        end
-        table.insert(target_x_per_image, x)
-        table.insert(target_y_per_image, y)  
-      end -- end for i_image = 1, #target_images do
-
-      -- print('*****************************************************')
-      -- print(string.format('collect mrf'));
-      -- print('*****************************************************')  
-      
-      local num_channel_mrf = net:get(mrf_layers[id_mrf] - 1).output:size()[1]
-      local target_mrf = torch.Tensor(target_x:nElement(), num_channel_mrf * params.mrf_patch_size[id_mrf] * params.mrf_patch_size[id_mrf])
-      local tensor_target_mrf = torch.Tensor(target_x:nElement(), num_channel_mrf, params.mrf_patch_size[id_mrf], params.mrf_patch_size[id_mrf])
-      local count_mrf = 1
-      for i_image = 1, #target_images_caffe do
-        -- print(string.format('image %d, ', i_image));
-        net:forward(target_images_caffe[i_image])
-        -- sample mrf on mrf_layers
-        local tensor_target_mrf_, target_mrf_ = sampleMRFAndTensorfromLocation2(target_x_per_image[i_image], target_y_per_image[i_image], net:get(mrf_layers[id_mrf] - 1).output:float(), params.mrf_patch_size[id_mrf])        
-        target_mrf[{{count_mrf, count_mrf + target_mrf_:size()[1] - 1}, {1, target_mrf:size()[2]}}] = target_mrf_:clone()
-        tensor_target_mrf[{{count_mrf, count_mrf + target_mrf_:size()[1] - 1}, {1, tensor_target_mrf:size()[2]}, {1, tensor_target_mrf:size()[3]}, {1, tensor_target_mrf:size()[4]}}] = tensor_target_mrf_:clone()
-        count_mrf = count_mrf + target_mrf_:size()[1]
-        tensor_target_mrf_ = nil
-        target_mrf_ = nil
-        collectgarbage()
-      end --for i_image = 1, #target_images do
-      local target_mrfnorm = torch.sqrt(torch.sum(torch.cmul(target_mrf, target_mrf), 2)):resize(target_mrf:size()[1], 1, 1)
-
-      --------------------------------------------------------
-      -- process source
-      --------------------------------------------------------
-      -- print('*****************************************************')
-      -- print(string.format('process source image'));
-      -- print('*****************************************************')
-      if params.backend == 'cudnn' then
-        net:forward(pyramid_source_image_caffe[cur_res]:cuda())
-	  else
-        net:forward(pyramid_source_image_caffe[cur_res]:cl())
-	  end
-      local source_feature_map = net:get(mrf_layers[id_mrf] - 1).output:float()
-      if params.mrf_patch_size[id_mrf] > source_feature_map:size()[2] or params.mrf_patch_size[id_mrf] > source_feature_map:size()[3] then 
-        print('source_image_caffe is not big enough for patch')
-        print('source_image_caffe size: ')
-        print(source_feature_map:size())
-        print('patch size: ')
-        print(params.mrf_patch_size[id_mrf])
-        do return end
-      end 
-      local source_xgrid, source_ygrid = drill_computeMRFfull(source_feature_map:float(), params.mrf_patch_size[id_mrf], params.source_sample_stride[id_mrf], -1) 
-      local source_x = torch.Tensor(source_xgrid:nElement() * source_ygrid:nElement())
-      local source_y = torch.Tensor(source_xgrid:nElement() * source_ygrid:nElement())      
-      local count = 1
-      for i_row = 1, source_ygrid:nElement() do
-        for i_col = 1, source_xgrid:nElement() do
-          source_x[count] = source_xgrid[i_col]
-          source_y[count] = source_ygrid[i_row]
-          count = count + 1
-        end
-      end
-      -- local tensor_target_mrfnorm = torch.repeatTensor(target_mrfnorm:float(), 1, net:get(mrf_layers[id_mrf] - 1).output:size()[2] - (params.mrf_patch_size[id_mrf] - 1), net:get(mrf_layers[id_mrf] - 1).output:size()[3] - (params.mrf_patch_size[id_mrf] - 1)) 
-
-      -- print('*****************************************************')
-      -- print(string.format('call layer implemetation'));
-      -- print('*****************************************************')  
-      local nInputPlane = target_mrf:size()[2] / (params.mrf_patch_size[id_mrf] * params.mrf_patch_size[id_mrf])
-      local nOutputPlane = target_mrf:size()[1]
-      local kW = params.mrf_patch_size[id_mrf]
-      local kH = params.mrf_patch_size[id_mrf]
-      local dW = 1
-      local dH = 1
-      local input_size = source_feature_map:size()
-
-      local source_xgrid_, source_ygrid_ = drill_computeMRFfull(source_feature_map:float(), params.mrf_patch_size[id_mrf], 1, -1) 
-      local response_size = torch.LongStorage(3) 
-      response_size[1] = nOutputPlane
-      response_size[2] = source_ygrid_:nElement()
-      response_size[3] = source_xgrid_:nElement()
-      net:get(mrf_layers[id_mrf]):implement(params.mode, target_mrf, tensor_target_mrf, target_mrfnorm, source_x, source_y, input_size, response_size, nInputPlane, nOutputPlane, kW, kH, 1, 1, params.mrf_confidence_threshold[id_mrf], params.mrf_weight[id_mrf], params.gpu_chunck_size_1, params.gpu_chunck_size_2, params.backend)
-      target_mrf = nil
-      tensor_target_mrf = nil
-      source_feature_map = nil
-      collectgarbage()
-    end
-
-    --------------------------------------------------------------------------------------------------------
-    -- local function for printing inter-mediate result
-    --------------------------------------------------------------------------------------------------------
-    local function maybe_print(t, loss)
-      local verbose = (params.print_iter > 0 and t % params.print_iter == 0)
-      if verbose then
-          print(string.format('Iteration %d, %d', t, params.num_iter[cur_res]))
-       end
-    end
-
-    --------------------------------------------------------------------------------------------------------
-    -- local function for saving inter-mediate result
-    --------------------------------------------------------------------------------------------------------
-    local function maybe_save(t)
-      local should_save = params.save_iter > 0 and t % params.save_iter == 0
-      should_save = should_save or t == params.num_iter
-      if should_save then
-      local disp = deprocess(input_image:float())
-      disp = image.minmax{tensor=disp, min=0, max=1}
-      disp = image.scale(disp, render_width, render_height, 'bilinear')
-      filename = params.output_folder .. '/' .. 'res_' .. cur_res .. '_' .. t .. '.jpg'
-      image.save(filename, disp)
-      end
-    end
-
-    --------------------------------------------------------------------------------------------------------
-    -- local function for computing energy
-    --------------------------------------------------------------------------------------------------------      
-    local function feval(x)
-      num_calls = num_calls + 1
-      net:forward(x)
-      local grad = net:backward(x, dy)
-      local loss = 0
-      collectgarbage()
-
-      maybe_print(num_calls, loss)
-      maybe_save(num_calls)
-
-      -- optim.lbfgs expects a vector for gradients
-      return loss, grad:view(grad:nElement())
-    end
-
-    -------------------------------------------------------------------------------
-    -- initialize network
-    ------------------------------------------------------------------------------- 
-    if params.gpu >= 0 then
-      if params.backend == 'cudnn' then
-        require 'cutorch'
-        require 'cunn'
-        cutorch.setDevice(params.gpu + 1)
-	  else
-        require 'cltorch'
-        require 'clnn'
-        cltorch.setDevice(params.gpu + 1)
-	  end
-
-    else
-      params.backend = 'nn-cpu'
-    end
-
-    if params.backend == 'cudnn' then
-      require 'cudnn'
-    end
-
-    local loadcaffe_backend = params.backend
-    if params.backend == 'clnn' then
-      loadcaffe_backend = 'nn'
-    end
-    local cnn = loadcaffe.load(params.proto_file, params.model_file, loadcaffe_backend):float()
-    if params.gpu >= 0 then
-      if params.backend == 'cudnn' then
-        cnn:cuda()
-	  else
-        cnn:cl()
-	  end
-    end
-    print('cnn succesfully loaded')
-
-    for i_res = 1, params.num_res do
-      local timer = torch.Timer()
-
-      cur_res = i_res
-      num_calls = 0
-      local optim_state = {
-        maxIter = params.num_iter[i_res],
-        nCorrection = params.nCorrection,
-        verbose=true,
-        tolX = 0,
-        tolFun = 0,
-      }  
-
-      -- initialize image and target
-      if i_res == 1 then
-
-        if params.ini_method == 'random' then
-          input_image = torch.randn(pyramid_source_image_caffe[i_res]:size()):float():mul(0.001)
-        elseif params.ini_method == 'image' then
-          input_image = pyramid_source_image_caffe[i_res]:clone():float()
-        else
-          error('Invalid init type')
-        end
-        if params.backend == 'cudnn' then
-          input_image = input_image:cuda()
-        else
-          input_image = input_image:cl()
-        end
-
-        -----------------------------------------------------
-        -- add a tv layer
-        -----------------------------------------------------    
-        if params.tv_weight > 0 then
-          local tv_mod = nn.TVLoss(params.tv_weight):float()
-          if params.gpu >= 0 then
-            if params.backend == 'cudnn' then
-              tv_mod:cuda()
-            else
-              tv_mod:cl()
-            end
-          end
-          i_net_layer = i_net_layer + 1
-          net:add(tv_mod)
-        end
-        
-        for i = 1, #cnn do
-          if next_mrf_idx <= #mrf_layers_pretrained then
-            local layer = cnn:get(i)
-
-            i_net_layer = i_net_layer + 1
-            net:add(layer)
-
-            -- -- add mrfstatsyn layer
-            if i == mrf_layers_pretrained[next_mrf_idx] then
-              if add_mrf() == false then
-                print('build network failed: adding mrf layer failed')
-                do return end
-              end
-            end
-
-          end
-        end -- for i = 1, #cnn do
-
-        cnn = nil
-        collectgarbage()
-        
-        print(net)
-
-
-        print('mrf_layers: ')
-        for i = 1, #mrf_layers do
-          print(mrf_layers[i])
-        end
-
-        print('network has been built.')
-      else
-        input_image = image.scale(input_image:float(), pyramid_source_image_caffe[i_res]:size()[3], pyramid_source_image_caffe[i_res]:size()[2], 'bilinear'):clone()
-        if params.backend == 'cudnn' then
-          input_image = input_image:cuda()
-        else
-          input_image = input_image:cl()
-        end
-
-      end
-
-      print('*****************************************************')
-      print('Synthesis started at resolution ' .. cur_res)
-      print('*****************************************************')
-
-      print('Implementing mrf layers ...')
-      for i = 1, #mrf_layers do
-        if build_mrf(i) == false then
-          print('build_mrf failed')
-          do return end
-        end
-      end
-
-      mask = torch.Tensor(input_image:size()):fill(1)
-      if params.backend == 'cudnn' then
-        mask = mask:cuda()
-      else
-        mask = mask:cl()
-      end
-        
-      y = net:forward(input_image)              
-      dy = input_image.new(#y):zero()
-
-      -- do optimizatoin
-      local x, losses = mylbfgs(feval, input_image, optim_state, nil, mask) 
-
-      local t = timer:time().real
-      print('Synthesis finished at resolution ' .. cur_res ..  ', ' .. t .. ' seconds')
-    end
-
-  net = nil
-  source_image = nil
-  target_image = nil
-  pyramid_source_image_caffe = nil
-  pyramid_target_image_caffe = nil
-  input_image = nil
-  output_image = nil
-  mrf_losses = nil
-  mrf_layers = nil
-  optim_state = nil
-  collectgarbage()  
-  collectgarbage()
-      
-  end -- end of main
-
-
-
-  function preprocess(img)
-    local mean_pixel = torch.Tensor({103.939, 116.779, 123.68})
-    local perm = torch.LongTensor{3, 2, 1}
-    img = img:index(1, perm):mul(256.0)
-    mean_pixel = mean_pixel:view(3, 1, 1):expandAs(img)
-    img:add(-1, mean_pixel)
-    return img
-  end
-
-  -- Undo the above preprocessing.
-  function deprocess(img)
-    local mean_pixel = torch.Tensor({103.939, 116.779, 123.68})
-    mean_pixel = mean_pixel:view(3, 1, 1):expandAs(img)
-    img = img + mean_pixel:float()
-    local perm = torch.LongTensor{3, 2, 1}
-    img = img:index(1, perm):div(256.0)
-    return img
-  end
-  
   main(params)
 
   local t_test = timer_TEST:time().real
-  print('Total time:  ' .. t_test .. 'seconds.') 
+  print(string.format('Total time: %f seconds', t_test))
   -- sleep(1)
   return flag_state
 end
 
 return {
-  state = run_test
+  run_test = run_test,
+  main = main
 }

--- a/transfer_CNNMRF_wrapper.lua
+++ b/transfer_CNNMRF_wrapper.lua
@@ -13,6 +13,11 @@ paths.dofile('mylib/content.lua')
 torch.setdefaulttensortype('torch.FloatTensor') -- float as default tensor type
 
 local function main(params)
+  os.execute('mkdir data/result/')
+  os.execute('mkdir data/result/trans/')
+  os.execute('mkdir data/result/trans/MRF/')
+  os.execute(string.format('mkdir %s', params.output_folder))
+
   local net = nn.Sequential()
   local next_content_idx = 1
   local i_net_layer = 0
@@ -317,7 +322,7 @@ local function main(params)
     local disp = deprocess(input_image:float())
     disp = image.minmax{tensor=disp, min=0, max=1}
     disp = image.scale(disp, render_width, render_height, 'bilinear')
-    local filename = string.format('%s/res_%d_%f.jpg', params.output_folder, cur_res, t)
+    local filename = string.format('%s/res_%d_%d.jpg', params.output_folder, cur_res, t)
     image.save(filename, disp)
     end
   end
@@ -570,10 +575,6 @@ local function run_test(content_name, style_name, ini_method, max_size, num_res,
   params.save_iter = 10
 
   params.output_folder = string.format('data/result/trans/MRF/%s_TO_%s',params.content_name,  params.style_name)
-  os.execute('mkdir data/result/')
-  os.execute('mkdir data/result/trans/')
-  os.execute('mkdir data/result/trans/MRF/')
-  os.execute(string.format('mkdir %s', params.output_folder))
 
   main(params)
 

--- a/transfer_CNNMRF_wrapper.lua
+++ b/transfer_CNNMRF_wrapper.lua
@@ -4,7 +4,522 @@ require 'image'
 require 'paths'
 require 'loadcaffe'
 
+paths.dofile('mylib/myoptimizer.lua')
+paths.dofile('mylib/tv.lua')
+paths.dofile('mylib/mrf.lua')
+paths.dofile('mylib/helper.lua')
+paths.dofile('mylib/content.lua')
+
 torch.setdefaulttensortype('torch.FloatTensor') -- float as default tensor type
+
+local function main(params)
+  local net = nn.Sequential()
+  local next_content_idx = 1
+  local i_net_layer = 0
+  local num_calls = 0
+  local content_losses = {}
+  local content_layers = {}
+  local i_content_layer = 0
+  local next_mrf_idx = 1
+  local mrf_losses = {}
+  local mrf_layers = {}
+  local i_mrf_layer = 0
+  local input_image
+  local output_image
+  local cur_res
+  local content_layers_pretrained = params.content_layers
+  local mrf_layers_pretrained = params.mrf_layers
+
+  -----------------------------------------------------------------------------------
+  -- read images
+  -----------------------------------------------------------------------------------
+  local source_image = image.load(string.format('data/content/%s.jpg', params.content_name), 3)
+  local target_image = image.load(string.format('data/style/%s.jpg', params.style_name), 3)
+
+  source_image = image.scale(source_image, params.max_size, 'bilinear')
+  target_image = image.scale(target_image, params.max_size, 'bilinear')
+
+  local render_height = source_image:size()[2]
+  local render_width = source_image:size()[3]
+  local source_image_caffe = preprocess(source_image):float()
+  local target_image_caffe = preprocess(target_image):float()
+
+  local pyramid_source_image_caffe = {}
+  for i_res = 1, params.num_res do
+    pyramid_source_image_caffe[i_res] = image.scale(source_image_caffe, math.ceil(source_image:size()[3] * math.pow(0.5, params.num_res - i_res)), math.ceil(source_image:size()[2] * math.pow(0.5, params.num_res - i_res)), 'bilinear')
+  end
+
+  local pyramid_target_image_caffe = {}
+  for i_res = 1, params.num_res do
+    pyramid_target_image_caffe[i_res] = image.scale(target_image_caffe, math.ceil(target_image:size()[3] * math.pow(0.5, params.num_res - i_res)), math.ceil(target_image:size()[2] * math.pow(0.5, params.num_res - i_res)), 'bilinear')
+  end
+
+  ------------------------------------------------------------------------------------------------------
+  -- local function for adding a content layer
+  ------------------------------------------------------------------------------------------------------
+  local function add_content()
+    local source =  pyramid_source_image_caffe[cur_res]:clone()
+    if params.gpu >= 0 then
+      if params.backend == 'cudnn' then
+        source = source:cuda()
+      else
+        source = source:cl()
+      end
+    end
+    local feature = net:forward(source):clone() -- generate the content target using content image
+    if params.gpu >= 0 then
+      if params.backend == 'cudnn' then
+        feature = feature:cuda()
+      else
+        feature = feature:cl()
+      end
+    end
+
+    local norm = params.normalize_gradients
+    print(params.normalize_gradients)
+    local loss_module = nn.ContentLoss(params.content_weight, feature, norm):float()
+    if params.gpu >= 0 then
+      if params.backend == 'cudnn' then
+        loss_module:cuda()
+      else
+        loss_module:cl()
+      end
+    end
+
+    i_content_layer = i_content_layer + 1
+    i_net_layer = i_net_layer + 1
+    next_content_idx = next_content_idx + 1
+    net:add(loss_module)
+    table.insert(content_losses, loss_module)
+    table.insert(content_layers, i_content_layer, i_net_layer)
+  end
+
+  local function update_content(idx_layer, idx_content)
+    local source =  pyramid_source_image_caffe[cur_res]:clone()
+    if params.gpu >= 0 then
+      if params.backend == 'cudnn' then
+        source = source:cuda()
+      else
+        source = source:cl()
+      end
+    end
+    net:forward(source)
+    local feature = net:get(idx_layer).output:clone()
+    if params.gpu >= 0 then
+      if params.backend == 'cudnn' then
+        feature = feature:cuda()
+      else
+        feature = feature:cl()
+      end
+    end
+
+    local norm = params.normalize_gradients
+    local loss_module = nn.ContentLoss(params.content_weight, feature, norm):float()
+    if params.gpu >= 0 then
+      if params.backend == 'cudnn' then
+        loss_module:cuda()
+      else
+        loss_module:cl()
+      end
+    end
+    net:get(idx_layer):update(loss_module)
+  end
+
+
+  -- --------------------------------------------------------------------------------------------------------
+  -- -- local function for adding a mrf layer, with image rotation andn scaling
+  -- --------------------------------------------------------------------------------------------------------
+  local function add_mrf()
+      local mrf_module = nn.MRFMM()
+      i_mrf_layer = i_mrf_layer + 1
+      i_net_layer = i_net_layer + 1
+      next_mrf_idx = next_mrf_idx + 1
+      if params.gpu >= 0 then
+        if params.backend == 'cudnn' then
+          mrf_module:cuda()
+        else
+          mrf_module:cl()
+        end
+      end
+      net:add(mrf_module)
+      table.insert(mrf_losses, mrf_module)
+      table.insert(mrf_layers, i_mrf_layer, i_net_layer)
+      return true
+  end
+
+  local function build_mrf(id_mrf)
+    --------------------------------------------------------
+    -- deal with target
+    --------------------------------------------------------
+    local target_images_caffe = {}
+    for i_r = -params.target_num_rotation, params.target_num_rotation do
+      local alpha = params.target_step_rotation * i_r
+      local min_x, min_y, max_x, max_y = computeBB(pyramid_target_image_caffe[cur_res]:size()[3], pyramid_target_image_caffe[cur_res]:size()[2], alpha)
+      local target_image_rt_caffe = image.rotate(pyramid_target_image_caffe[cur_res], alpha, 'bilinear')
+      target_image_rt_caffe = target_image_rt_caffe[{{1, target_image_rt_caffe:size()[1]}, {min_y, max_y}, {min_x, max_x}}]
+
+      for i_s = -params.target_num_scale, params.target_num_scale do
+        local max_sz = math.floor(math.max(target_image_rt_caffe:size()[2], target_image_rt_caffe:size()[3]) * torch.pow(params.target_step_scale, i_s))
+        local target_image_rt_s_caffe = image.scale(target_image_rt_caffe, max_sz, 'bilinear')
+        if params.backend == 'cudnn' then
+          target_image_rt_s_caffe = target_image_rt_s_caffe:cuda()
+        else
+          target_image_rt_s_caffe = target_image_rt_s_caffe:cl()
+        end
+        table.insert(target_images_caffe, target_image_rt_s_caffe)
+      end
+    end
+
+    -- compute the coordinates on the pixel layer
+    local target_x
+    local target_y
+    local target_x_per_image = {}
+    local target_y_per_image = {}
+    local target_imageid
+    -- print('*****************************************************')
+    -- print(string.format('build target mrf'));
+    -- print('*****************************************************')
+    for i_image = 1, #target_images_caffe do
+      -- print(string.format('image %d, ', i_image))
+      net:forward(target_images_caffe[i_image])
+      local target_feature_map = net:get(mrf_layers[id_mrf] - 1).output:float()
+
+      if params.mrf_patch_size[id_mrf] > target_feature_map:size()[2] or params.mrf_patch_size[id_mrf] > target_feature_map:size()[3] then
+        print('target_images is not big enough for patch')
+        print('target_images size: ')
+        print(target_feature_map:size())
+        print('patch size: ')
+        print(params.mrf_patch_size[id_mrf])
+        do return end
+      end
+      local target_x_, target_y_ = drill_computeMRFfull(target_feature_map,  params.mrf_patch_size[id_mrf], params.target_sample_stride[id_mrf], -1)
+
+
+      local x = torch.Tensor(target_x_:nElement() * target_y_:nElement())
+      local y = torch.Tensor(target_x_:nElement() * target_y_:nElement())
+      local target_imageid_ = torch.Tensor(target_x_:nElement() * target_y_:nElement()):fill(i_image)
+      local count = 1
+      for i_row = 1, target_y_:nElement() do
+        for i_col = 1, target_x_:nElement() do
+          x[count] = target_x_[i_col]
+          y[count] = target_y_[i_row]
+          count = count + 1
+        end
+      end
+      if i_image == 1 then
+        target_x = x:clone()
+        target_y = y:clone()
+        target_imageid = target_imageid_:clone()
+      else
+        target_x = torch.cat(target_x, x, 1)
+        target_y = torch.cat(target_y, y, 1)
+        target_imageid = torch.cat(target_imageid, target_imageid_, 1)
+      end
+      table.insert(target_x_per_image, x)
+      table.insert(target_y_per_image, y)
+    end -- end for i_image = 1, #target_images do
+
+    -- print('*****************************************************')
+    -- print(string.format('collect mrf'));
+    -- print('*****************************************************')
+
+    local num_channel_mrf = net:get(mrf_layers[id_mrf] - 1).output:size()[1]
+    local target_mrf = torch.Tensor(target_x:nElement(), num_channel_mrf * params.mrf_patch_size[id_mrf] * params.mrf_patch_size[id_mrf])
+    local tensor_target_mrf = torch.Tensor(target_x:nElement(), num_channel_mrf, params.mrf_patch_size[id_mrf], params.mrf_patch_size[id_mrf])
+    local count_mrf = 1
+    for i_image = 1, #target_images_caffe do
+      -- print(string.format('image %d, ', i_image));
+      net:forward(target_images_caffe[i_image])
+      -- sample mrf on mrf_layers
+      local tensor_target_mrf_, target_mrf_ = sampleMRFAndTensorfromLocation2(target_x_per_image[i_image], target_y_per_image[i_image], net:get(mrf_layers[id_mrf] - 1).output:float(), params.mrf_patch_size[id_mrf])
+      target_mrf[{{count_mrf, count_mrf + target_mrf_:size()[1] - 1}, {1, target_mrf:size()[2]}}] = target_mrf_:clone()
+      tensor_target_mrf[{{count_mrf, count_mrf + target_mrf_:size()[1] - 1}, {1, tensor_target_mrf:size()[2]}, {1, tensor_target_mrf:size()[3]}, {1, tensor_target_mrf:size()[4]}}] = tensor_target_mrf_:clone()
+      count_mrf = count_mrf + target_mrf_:size()[1]
+      tensor_target_mrf_ = nil
+      target_mrf_ = nil
+      collectgarbage()
+    end --for i_image = 1, #target_images do
+    local target_mrfnorm = torch.sqrt(torch.sum(torch.cmul(target_mrf, target_mrf), 2)):resize(target_mrf:size()[1], 1, 1)
+
+    --------------------------------------------------------
+    -- process source
+    --------------------------------------------------------
+    -- print('*****************************************************')
+    -- print(string.format('process source image'));
+    -- print('*****************************************************')
+    if params.backend == 'cudnn' then
+      net:forward(pyramid_source_image_caffe[cur_res]:cuda())
+    else
+      net:forward(pyramid_source_image_caffe[cur_res]:cl())
+    end
+    local source_feature_map = net:get(mrf_layers[id_mrf] - 1).output:float()
+    if params.mrf_patch_size[id_mrf] > source_feature_map:size()[2] or params.mrf_patch_size[id_mrf] > source_feature_map:size()[3] then
+      print('source_image_caffe is not big enough for patch')
+      print('source_image_caffe size: ')
+      print(source_feature_map:size())
+      print('patch size: ')
+      print(params.mrf_patch_size[id_mrf])
+      do return end
+    end
+    local source_xgrid, source_ygrid = drill_computeMRFfull(source_feature_map:float(), params.mrf_patch_size[id_mrf], params.source_sample_stride[id_mrf], -1)
+    local source_x = torch.Tensor(source_xgrid:nElement() * source_ygrid:nElement())
+    local source_y = torch.Tensor(source_xgrid:nElement() * source_ygrid:nElement())
+    local count = 1
+    for i_row = 1, source_ygrid:nElement() do
+      for i_col = 1, source_xgrid:nElement() do
+        source_x[count] = source_xgrid[i_col]
+        source_y[count] = source_ygrid[i_row]
+        count = count + 1
+      end
+    end
+    -- local tensor_target_mrfnorm = torch.repeatTensor(target_mrfnorm:float(), 1, net:get(mrf_layers[id_mrf] - 1).output:size()[2] - (params.mrf_patch_size[id_mrf] - 1), net:get(mrf_layers[id_mrf] - 1).output:size()[3] - (params.mrf_patch_size[id_mrf] - 1))
+
+    -- print('*****************************************************')
+    -- print(string.format('call layer implemetation'));
+    -- print('*****************************************************')
+    local nInputPlane = target_mrf:size()[2] / (params.mrf_patch_size[id_mrf] * params.mrf_patch_size[id_mrf])
+    local nOutputPlane = target_mrf:size()[1]
+    local kW = params.mrf_patch_size[id_mrf]
+    local kH = params.mrf_patch_size[id_mrf]
+    local dW = 1
+    local dH = 1
+    local input_size = source_feature_map:size()
+
+    local source_xgrid_, source_ygrid_ = drill_computeMRFfull(source_feature_map:float(), params.mrf_patch_size[id_mrf], 1, -1)
+    local response_size = torch.LongStorage(3)
+    response_size[1] = nOutputPlane
+    response_size[2] = source_ygrid_:nElement()
+    response_size[3] = source_xgrid_:nElement()
+    net:get(mrf_layers[id_mrf]):implement(params.mode, target_mrf, tensor_target_mrf, target_mrfnorm, source_x, source_y, input_size, response_size, nInputPlane, nOutputPlane, kW, kH, 1, 1, params.mrf_confidence_threshold[id_mrf], params.mrf_weight[id_mrf], params.gpu_chunck_size_1, params.gpu_chunck_size_2, params.backend)
+    target_mrf = nil
+    tensor_target_mrf = nil
+    source_feature_map = nil
+    collectgarbage()
+  end
+
+  --------------------------------------------------------------------------------------------------------
+  -- local function for printing inter-mediate result
+  --------------------------------------------------------------------------------------------------------
+  local function maybe_print(t, loss)
+    local verbose = (params.print_iter > 0 and t % params.print_iter == 0)
+    if verbose then
+        print(string.format('Iteration %d, %d', t, params.num_iter[cur_res]))
+     end
+  end
+
+  --------------------------------------------------------------------------------------------------------
+  -- local function for saving inter-mediate result
+  --------------------------------------------------------------------------------------------------------
+  local function maybe_save(t)
+    local should_save = params.save_iter > 0 and t % params.save_iter == 0
+    should_save = should_save or t == params.num_iter
+    if should_save then
+    local disp = deprocess(input_image:float())
+    disp = image.minmax{tensor=disp, min=0, max=1}
+    disp = image.scale(disp, render_width, render_height, 'bilinear')
+    local filename = string.format('%s/res_%d_%f.jpg', params.output_folder, cur_res, t)
+    image.save(filename, disp)
+    end
+  end
+
+  --------------------------------------------------------------------------------------------------------
+  -- local function for computing energy
+  --------------------------------------------------------------------------------------------------------
+  local function feval(x)
+    num_calls = num_calls + 1
+    net:forward(x)
+    local grad = net:backward(x, dy)
+    local loss = 0
+    collectgarbage()
+
+    maybe_print(num_calls, loss)
+    maybe_save(num_calls)
+
+    -- optim.lbfgs expects a vector for gradients
+    return loss, grad:view(grad:nElement())
+  end
+
+  -------------------------------------------------------------------------------
+  -- initialize network
+  -------------------------------------------------------------------------------
+  if params.gpu >= 0 then
+    if params.backend == 'cudnn' then
+      require 'cutorch'
+      require 'cunn'
+      cutorch.setDevice(params.gpu + 1)
+    else
+      require 'cltorch'
+      require 'clnn'
+      cltorch.setDevice(params.gpu + 1)
+    end
+  else
+    params.backend = 'nn-cpu'
+  end
+
+  if params.backend == 'cudnn' then
+    require 'cudnn'
+  end
+
+  local loadcaffe_backend = params.backend
+  if params.backend == 'clnn' then
+    loadcaffe_backend = 'nn'
+  end
+  local cnn = loadcaffe.load(params.proto_file, params.model_file, loadcaffe_backend):float()
+  if params.gpu >= 0 then
+    if params.backend == 'cudnn' then
+      cnn:cuda()
+    else
+      cnn:cl()
+    end
+  end
+  print('cnn succesfully loaded')
+
+  for i_res = 1, params.num_res do
+    local timer = torch.Timer()
+
+    cur_res = i_res
+    num_calls = 0
+    local optim_state = {
+      maxIter = params.num_iter[i_res],
+      nCorrection = params.nCorrection,
+      verbose=true,
+      tolX = 0,
+      tolFun = 0,
+    }
+
+    -- initialize image and target
+    if i_res == 1 then
+
+      if params.ini_method == 'random' then
+        input_image = torch.randn(pyramid_source_image_caffe[i_res]:size()):float():mul(0.001)
+      elseif params.ini_method == 'image' then
+        input_image = pyramid_source_image_caffe[i_res]:clone():float()
+      else
+        error('Invalid init type')
+      end
+      if params.backend == 'cudnn' then
+        input_image = input_image:cuda()
+      else
+        input_image = input_image:cl()
+      end
+
+      -----------------------------------------------------
+      -- add a tv layer
+      -----------------------------------------------------
+      if params.tv_weight > 0 then
+        local tv_mod = nn.TVLoss(params.tv_weight):float()
+        if params.gpu >= 0 then
+          if params.backend == 'cudnn' then
+            tv_mod:cuda()
+          else
+            tv_mod:cl()
+          end
+        end
+        i_net_layer = i_net_layer + 1
+        net:add(tv_mod)
+      end
+
+      for i = 1, #cnn do
+        if next_content_idx <= #content_layers_pretrained or next_mrf_idx <= #mrf_layers_pretrained then
+          local layer = cnn:get(i)
+
+          i_net_layer = i_net_layer + 1
+          net:add(layer)
+
+          -- add a content_losses layer
+          if i == content_layers_pretrained[next_content_idx] then
+            add_content()
+          end
+
+          -- -- add mrfstatsyn layer
+          if i == mrf_layers_pretrained[next_mrf_idx] then
+            if add_mrf() == false then
+              print('build network failed: adding mrf layer failed')
+              do return end
+            end
+          end
+
+        end
+      end -- for i = 1, #cnn do
+
+      cnn = nil
+      collectgarbage()
+
+      print(net)
+
+      print('content_layers: ')
+      for i = 1, #content_layers do
+        print(content_layers[i])
+      end
+
+      print('mrf_layers: ')
+      for i = 1, #mrf_layers do
+        print(mrf_layers[i])
+      end
+
+      print('network has been built.')
+    else
+      input_image = image.scale(input_image:float(), pyramid_source_image_caffe[i_res]:size()[3], pyramid_source_image_caffe[i_res]:size()[2], 'bilinear'):clone()
+      if params.backend == 'cudnn' then
+        input_image = input_image:cuda()
+      else
+        input_image = input_image:cl()
+      end
+
+      -- -- update content layers
+      for i_layer = 1, #content_layers do
+        update_content(content_layers[i_layer], i_layer)
+        -- print(string.format('content_layers %d has been updated', content_layers[i_layer]))
+      end
+
+    end
+
+    print('*****************************************************')
+    print(string.format('Synthesis started at resolution ', cur_res))
+    print('*****************************************************')
+
+    print('Implementing mrf layers ...')
+    for i = 1, #mrf_layers do
+      if build_mrf(i) == false then
+        print('build_mrf failed')
+        do return end
+      end
+    end
+
+    local mask = torch.Tensor(input_image:size()):fill(1)
+    if params.backend == 'cudnn' then
+      mask = mask:cuda()
+    else
+      mask = mask:cl()
+    end
+
+    y = net:forward(input_image)
+    dy = input_image.new(#y):zero()
+
+    -- do optimizatoin
+    local x, losses = mylbfgs(feval, input_image, optim_state, nil, mask)
+
+    local t = timer:time().real
+    print(string.format('Synthesis finished at resolution %d, %f seconds', cur_res, t))
+  end
+
+  net = nil
+  source_image = nil
+  target_image = nil
+  pyramid_source_image_caffe = nil
+  pyramid_target_image_caffe = nil
+  input_image = nil
+  output_image = nil
+  content_losses = nil
+  content_layers = nil
+  mrf_losses = nil
+  mrf_layers = nil
+  optim_state = nil
+  collectgarbage()
+  collectgarbage()
+
+end -- end of main
+
 
 local function run_test(content_name, style_name, ini_method, max_size, num_res, num_iter, mrf_layers, mrf_weight, mrf_patch_size, mrf_num_rotation, mrf_num_scale, mrf_sample_stride, mrf_synthesis_stride, mrf_confidence_threshold, content_layers, content_weight, tv_weight, mode, gpu_chunck_size_1, gpu_chunck_size_2, backend)
   -- local clock = os.clock
@@ -17,8 +532,7 @@ local function run_test(content_name, style_name, ini_method, max_size, num_res,
 
   local flag_state = 1
 
-  local cmd = torch.CmdLine()
-  local params = cmd:parse(arg)
+  local params = {}
 
   -- externally set paramters
   params.content_name = content_name
@@ -46,10 +560,8 @@ local function run_test(content_name, style_name, ini_method, max_size, num_res,
   -- fixed parameters
   params.target_step_rotation = math.pi/24
   params.target_step_scale = 1.05
-  os.execute('mkdir ' .. 'data/result/')
-  os.execute('mkdir ' .. 'data/result/trans/')
-  os.execute('mkdir ' .. 'data/result/trans/MRF/')
-  params.output_folder = 'data/result/trans/MRF/' .. params.content_name .. '_TO_' .. params.style_name
+
+  params.output_folder = string.format('data/result/trans/MRF/%s_TO_%s',params.content_name,  params.style_name)
   params.proto_file = 'data/models/VGG_ILSVRC_19_layers_deploy.prototxt'
   params.model_file = 'data/models/VGG_ILSVRC_19_layers.caffemodel'
   params.gpu = 0
@@ -57,546 +569,21 @@ local function run_test(content_name, style_name, ini_method, max_size, num_res,
   params.print_iter = 10
   params.save_iter = 10
 
+  params.output_folder = string.format('data/result/trans/MRF/%s_TO_%s',params.content_name,  params.style_name)
+  os.execute('mkdir data/result/')
+  os.execute('mkdir data/result/trans/')
+  os.execute('mkdir data/result/trans/MRF/')
+  os.execute(string.format('mkdir %s', params.output_folder))
 
-  os.execute('mkdir ' .. params.output_folder)
-
-  local function main(params)
-    local net = nn.Sequential()
-    local next_content_idx = 1
-    local i_net_layer = 0
-    local num_calls = 0
-    local content_losses = {}
-    local content_layers = {}
-    local i_content_layer = 0
-    local next_mrf_idx = 1
-    local mrf_losses = {}
-    local mrf_layers = {}
-    local i_mrf_layer = 0
-    local input_image
-    local output_image
-    local cur_res
-    local content_layers_pretrained = params.content_layers
-    local mrf_layers_pretrained = params.mrf_layers
-
-    -----------------------------------------------------------------------------------
-    -- read images
-    -----------------------------------------------------------------------------------
-    local source_image = image.load('data/content/' .. params.content_name  .. '.jpg', 3)
-    local target_image = image.load('data/style/' .. params.style_name  .. '.jpg', 3)
-
-    source_image = image.scale(source_image, params.max_size, 'bilinear')
-    target_image = image.scale(target_image, params.max_size, 'bilinear')
-
-    local render_height = source_image:size()[2]
-    local render_width = source_image:size()[3]
-    source_image_caffe = preprocess(source_image):float()
-    target_image_caffe = preprocess(target_image):float()
-
-    local pyramid_source_image_caffe = {}
-    for i_res = 1, params.num_res do
-      pyramid_source_image_caffe[i_res] = image.scale(source_image_caffe, math.ceil(source_image:size()[3] * math.pow(0.5, params.num_res - i_res)), math.ceil(source_image:size()[2] * math.pow(0.5, params.num_res - i_res)), 'bilinear')
-    end
-
-    local pyramid_target_image_caffe = {}
-    for i_res = 1, params.num_res do
-      pyramid_target_image_caffe[i_res] = image.scale(target_image_caffe, math.ceil(target_image:size()[3] * math.pow(0.5, params.num_res - i_res)), math.ceil(target_image:size()[2] * math.pow(0.5, params.num_res - i_res)), 'bilinear')
-    end
-
-    ------------------------------------------------------------------------------------------------------
-    -- local function for adding a content layer
-    ------------------------------------------------------------------------------------------------------
-    local function add_content()
-      local source =  pyramid_source_image_caffe[cur_res]:clone()
-      if params.gpu >= 0 then
-        if params.backend == 'cudnn' then
-          source = source:cuda()
-        else
-          source = source:cl()
-        end
-      end
-      local feature = net:forward(source):clone() -- generate the content target using content image
-      if params.gpu >= 0 then
-        if params.backend == 'cudnn' then
-          feature = feature:cuda()
-        else
-          feature = feature:cl()
-        end
-      end
-
-      local norm = params.normalize_gradients
-      local loss_module = nn.ContentLoss(params.content_weight, feature, norm):float()
-      if params.gpu >= 0 then
-        if params.backend == 'cudnn' then
-          loss_module:cuda()
-        else
-          loss_module:cl()
-        end
-      end
-
-      i_content_layer = i_content_layer + 1
-      i_net_layer = i_net_layer + 1
-      next_content_idx = next_content_idx + 1 
-      net:add(loss_module)
-      table.insert(content_losses, loss_module)
-      table.insert(content_layers, i_content_layer, i_net_layer)
-    end
-
-    local function update_content(idx_layer, idx_content)
-      local source =  pyramid_source_image_caffe[cur_res]:clone()
-      if params.gpu >= 0 then
-        if params.backend == 'cudnn' then
-          source = source:cuda()
-        else
-          source = source:cl()
-        end
-      end
-      net:forward(source)
-      local feature = net:get(idx_layer).output:clone()
-      if params.gpu >= 0 then
-        if params.backend == 'cudnn' then
-          feature = feature:cuda()
-        else
-          feature = feature:cl()
-        end
-      end
-
-      local norm = params.normalize_gradients
-      local loss_module = nn.ContentLoss(params.content_weight, feature, norm):float()
-      if params.gpu >= 0 then
-        if params.backend == 'cudnn' then
-          loss_module:cuda()
-        else
-          loss_module:cl()
-        end
-      end
-      net:get(idx_layer):update(loss_module)
-    end
-
-
-    -- --------------------------------------------------------------------------------------------------------
-    -- -- local function for adding a mrf layer, with image rotation andn scaling
-    -- --------------------------------------------------------------------------------------------------------
-    local function add_mrf()
-        local mrf_module = nn.MRFMM()
-        i_mrf_layer = i_mrf_layer + 1
-        i_net_layer = i_net_layer + 1
-        next_mrf_idx = next_mrf_idx + 1 
-        if params.gpu >= 0 then
-          if params.backend == 'cudnn' then
-            mrf_module:cuda()
-          else
-            mrf_module:cl()
-          end
-        end
-        net:add(mrf_module)
-        table.insert(mrf_losses, mrf_module)
-        table.insert(mrf_layers, i_mrf_layer, i_net_layer)
-        return true
-    end
-
-    local function build_mrf(id_mrf)
-      --------------------------------------------------------
-      -- deal with target
-      --------------------------------------------------------
-      target_images_caffe = {}
-      for i_r = -params.target_num_rotation, params.target_num_rotation do
-        local alpha = params.target_step_rotation * i_r 
-        local min_x, min_y, max_x, max_y = computeBB(pyramid_target_image_caffe[cur_res]:size()[3], pyramid_target_image_caffe[cur_res]:size()[2], alpha)
-        local target_image_rt_caffe = image.rotate(pyramid_target_image_caffe[cur_res], alpha, 'bilinear')
-        target_image_rt_caffe = target_image_rt_caffe[{{1, target_image_rt_caffe:size()[1]}, {min_y, max_y}, {min_x, max_x}}]
-
-        for i_s = -params.target_num_scale, params.target_num_scale do  
-          local max_sz = math.floor(math.max(target_image_rt_caffe:size()[2], target_image_rt_caffe:size()[3]) * torch.pow(params.target_step_scale, i_s))
-          local target_image_rt_s_caffe = image.scale(target_image_rt_caffe, max_sz, 'bilinear')
-          if params.backend == 'cudnn' then
-            target_image_rt_s_caffe = target_image_rt_s_caffe:cuda()
-          else
-            target_image_rt_s_caffe = target_image_rt_s_caffe:cl()
-          end
-          table.insert(target_images_caffe, target_image_rt_s_caffe)
-        end
-      end
-
-      -- compute the coordinates on the pixel layer
-      local target_x
-      local target_y
-      local target_x_per_image = {}
-      local target_y_per_image = {}
-      local target_imageid
-      -- print('*****************************************************')
-      -- print(string.format('build target mrf'));
-      -- print('*****************************************************')   
-      for i_image = 1, #target_images_caffe do
-        -- print(string.format('image %d, ', i_image))
-        net:forward(target_images_caffe[i_image])
-        local target_feature_map = net:get(mrf_layers[id_mrf] - 1).output:float()
-
-        if params.mrf_patch_size[id_mrf] > target_feature_map:size()[2] or params.mrf_patch_size[id_mrf] > target_feature_map:size()[3] then 
-          print('target_images is not big enough for patch')
-          print('target_images size: ')
-          print(target_feature_map:size())
-          print('patch size: ')
-          print(params.mrf_patch_size[id_mrf])
-          do return end
-        end 
-        local target_x_, target_y_ = drill_computeMRFfull(target_feature_map,  params.mrf_patch_size[id_mrf], params.target_sample_stride[id_mrf], -1) 
-
-
-        local x = torch.Tensor(target_x_:nElement() * target_y_:nElement())
-        local y = torch.Tensor(target_x_:nElement() * target_y_:nElement())
-        local target_imageid_ = torch.Tensor(target_x_:nElement() * target_y_:nElement()):fill(i_image)
-        local count = 1
-        for i_row = 1, target_y_:nElement() do
-          for i_col = 1, target_x_:nElement() do
-            x[count] = target_x_[i_col]
-            y[count] = target_y_[i_row]
-            count = count + 1
-          end
-        end
-        if i_image == 1 then
-          target_x = x:clone()
-          target_y = y:clone()
-          target_imageid = target_imageid_:clone()
-        else
-          target_x = torch.cat(target_x, x, 1)
-          target_y = torch.cat(target_y, y, 1)
-          target_imageid = torch.cat(target_imageid, target_imageid_, 1)
-        end
-        table.insert(target_x_per_image, x)
-        table.insert(target_y_per_image, y)  
-      end -- end for i_image = 1, #target_images do
-
-      -- print('*****************************************************')
-      -- print(string.format('collect mrf'));
-      -- print('*****************************************************')  
-      
-      local num_channel_mrf = net:get(mrf_layers[id_mrf] - 1).output:size()[1]
-      local target_mrf = torch.Tensor(target_x:nElement(), num_channel_mrf * params.mrf_patch_size[id_mrf] * params.mrf_patch_size[id_mrf])
-      local tensor_target_mrf = torch.Tensor(target_x:nElement(), num_channel_mrf, params.mrf_patch_size[id_mrf], params.mrf_patch_size[id_mrf])
-      local count_mrf = 1
-      for i_image = 1, #target_images_caffe do
-        -- print(string.format('image %d, ', i_image));
-        net:forward(target_images_caffe[i_image])
-        -- sample mrf on mrf_layers
-        local tensor_target_mrf_, target_mrf_ = sampleMRFAndTensorfromLocation2(target_x_per_image[i_image], target_y_per_image[i_image], net:get(mrf_layers[id_mrf] - 1).output:float(), params.mrf_patch_size[id_mrf])        
-        target_mrf[{{count_mrf, count_mrf + target_mrf_:size()[1] - 1}, {1, target_mrf:size()[2]}}] = target_mrf_:clone()
-        tensor_target_mrf[{{count_mrf, count_mrf + target_mrf_:size()[1] - 1}, {1, tensor_target_mrf:size()[2]}, {1, tensor_target_mrf:size()[3]}, {1, tensor_target_mrf:size()[4]}}] = tensor_target_mrf_:clone()
-        count_mrf = count_mrf + target_mrf_:size()[1]
-        tensor_target_mrf_ = nil
-        target_mrf_ = nil
-        collectgarbage()
-      end --for i_image = 1, #target_images do
-      local target_mrfnorm = torch.sqrt(torch.sum(torch.cmul(target_mrf, target_mrf), 2)):resize(target_mrf:size()[1], 1, 1)
-
-      --------------------------------------------------------
-      -- process source
-      --------------------------------------------------------
-      -- print('*****************************************************')
-      -- print(string.format('process source image'));
-      -- print('*****************************************************')
-      if params.backend == 'cudnn' then
-        net:forward(pyramid_source_image_caffe[cur_res]:cuda())
-      else
-        net:forward(pyramid_source_image_caffe[cur_res]:cl())
-      end
-      local source_feature_map = net:get(mrf_layers[id_mrf] - 1).output:float()
-      if params.mrf_patch_size[id_mrf] > source_feature_map:size()[2] or params.mrf_patch_size[id_mrf] > source_feature_map:size()[3] then 
-        print('source_image_caffe is not big enough for patch')
-        print('source_image_caffe size: ')
-        print(source_feature_map:size())
-        print('patch size: ')
-        print(params.mrf_patch_size[id_mrf])
-        do return end
-      end 
-      local source_xgrid, source_ygrid = drill_computeMRFfull(source_feature_map:float(), params.mrf_patch_size[id_mrf], params.source_sample_stride[id_mrf], -1) 
-      local source_x = torch.Tensor(source_xgrid:nElement() * source_ygrid:nElement())
-      local source_y = torch.Tensor(source_xgrid:nElement() * source_ygrid:nElement())      
-      local count = 1
-      for i_row = 1, source_ygrid:nElement() do
-        for i_col = 1, source_xgrid:nElement() do
-          source_x[count] = source_xgrid[i_col]
-          source_y[count] = source_ygrid[i_row]
-          count = count + 1
-        end
-      end
-      -- local tensor_target_mrfnorm = torch.repeatTensor(target_mrfnorm:float(), 1, net:get(mrf_layers[id_mrf] - 1).output:size()[2] - (params.mrf_patch_size[id_mrf] - 1), net:get(mrf_layers[id_mrf] - 1).output:size()[3] - (params.mrf_patch_size[id_mrf] - 1)) 
-
-      -- print('*****************************************************')
-      -- print(string.format('call layer implemetation'));
-      -- print('*****************************************************')  
-      local nInputPlane = target_mrf:size()[2] / (params.mrf_patch_size[id_mrf] * params.mrf_patch_size[id_mrf])
-      local nOutputPlane = target_mrf:size()[1]
-      local kW = params.mrf_patch_size[id_mrf]
-      local kH = params.mrf_patch_size[id_mrf]
-      local dW = 1
-      local dH = 1
-      local input_size = source_feature_map:size()
-
-      local source_xgrid_, source_ygrid_ = drill_computeMRFfull(source_feature_map:float(), params.mrf_patch_size[id_mrf], 1, -1) 
-      local response_size = torch.LongStorage(3) 
-      response_size[1] = nOutputPlane
-      response_size[2] = source_ygrid_:nElement()
-      response_size[3] = source_xgrid_:nElement()
-      net:get(mrf_layers[id_mrf]):implement(params.mode, target_mrf, tensor_target_mrf, target_mrfnorm, source_x, source_y, input_size, response_size, nInputPlane, nOutputPlane, kW, kH, 1, 1, params.mrf_confidence_threshold[id_mrf], params.mrf_weight[id_mrf], params.gpu_chunck_size_1, params.gpu_chunck_size_2, params.backend)
-      target_mrf = nil
-      tensor_target_mrf = nil
-      source_feature_map = nil
-      collectgarbage()
-    end
-
-    --------------------------------------------------------------------------------------------------------
-    -- local function for printing inter-mediate result
-    --------------------------------------------------------------------------------------------------------
-    local function maybe_print(t, loss)
-      local verbose = (params.print_iter > 0 and t % params.print_iter == 0)
-      if verbose then
-          print(string.format('Iteration %d, %d', t, params.num_iter[cur_res]))
-       end
-    end
-
-    --------------------------------------------------------------------------------------------------------
-    -- local function for saving inter-mediate result
-    --------------------------------------------------------------------------------------------------------
-    local function maybe_save(t)
-      local should_save = params.save_iter > 0 and t % params.save_iter == 0
-      should_save = should_save or t == params.num_iter
-      if should_save then
-      local disp = deprocess(input_image:float())
-      disp = image.minmax{tensor=disp, min=0, max=1}
-      disp = image.scale(disp, render_width, render_height, 'bilinear')
-      filename = params.output_folder .. '/' .. 'res_' .. cur_res .. '_' .. t .. '.jpg'
-      image.save(filename, disp)
-      end
-    end
-
-    --------------------------------------------------------------------------------------------------------
-    -- local function for computing energy
-    --------------------------------------------------------------------------------------------------------      
-    local function feval(x)
-      num_calls = num_calls + 1
-      net:forward(x)
-      local grad = net:backward(x, dy)
-      local loss = 0
-      collectgarbage()
-
-      maybe_print(num_calls, loss)
-      maybe_save(num_calls)
-
-      -- optim.lbfgs expects a vector for gradients
-      return loss, grad:view(grad:nElement())
-    end
-
-    -------------------------------------------------------------------------------
-    -- initialize network
-    ------------------------------------------------------------------------------- 
-    if params.gpu >= 0 then
-      if params.backend == 'cudnn' then
-        require 'cutorch'
-        require 'cunn'
-        cutorch.setDevice(params.gpu + 1)
-      else
-        require 'cltorch'
-        require 'clnn'
-        cltorch.setDevice(params.gpu + 1)
-      end
-    else
-      params.backend = 'nn-cpu'
-    end
-
-    if params.backend == 'cudnn' then
-      require 'cudnn'
-    end
-
-    local loadcaffe_backend = params.backend
-    if params.backend == 'clnn' then
-      loadcaffe_backend = 'nn'
-    end
-    local cnn = loadcaffe.load(params.proto_file, params.model_file, loadcaffe_backend):float()
-    if params.gpu >= 0 then
-      if params.backend == 'cudnn' then
-        cnn:cuda()
-      else
-        cnn:cl()
-      end
-    end
-    print('cnn succesfully loaded')
-
-    for i_res = 1, params.num_res do
-      local timer = torch.Timer()
-
-      cur_res = i_res
-      num_calls = 0
-      local optim_state = {
-        maxIter = params.num_iter[i_res],
-        nCorrection = params.nCorrection,
-        verbose=true,
-        tolX = 0,
-        tolFun = 0,
-      }  
-
-      -- initialize image and target
-      if i_res == 1 then
-
-        if params.ini_method == 'random' then
-          input_image = torch.randn(pyramid_source_image_caffe[i_res]:size()):float():mul(0.001)
-        elseif params.ini_method == 'image' then
-          input_image = pyramid_source_image_caffe[i_res]:clone():float()
-        else
-          error('Invalid init type')
-        end
-
-        if params.backend == 'cudnn' then
-          input_image = input_image:cuda()
-        else
-          input_image = input_image:cl()
-        end
-
-        -----------------------------------------------------
-        -- add a tv layer
-        -----------------------------------------------------    
-        if params.tv_weight > 0 then
-          local tv_mod = nn.TVLoss(params.tv_weight):float()
-          if params.gpu >= 0 then
-            if params.backend == 'cudnn' then
-              tv_mod:cuda()
-            else
-              tv_mod:cl()
-            end
-          end
-          i_net_layer = i_net_layer + 1
-          net:add(tv_mod)
-        end
-        
-        for i = 1, #cnn do
-          if next_content_idx <= #content_layers_pretrained or next_mrf_idx <= #mrf_layers_pretrained then
-            local layer = cnn:get(i)
-
-            i_net_layer = i_net_layer + 1
-            net:add(layer)
-
-            -- add a content_losses layer
-            if i == content_layers_pretrained[next_content_idx] then
-              add_content()
-            end
-
-            -- -- add mrfstatsyn layer
-            if i == mrf_layers_pretrained[next_mrf_idx] then
-              if add_mrf() == false then
-                print('build network failed: adding mrf layer failed')
-                do return end
-              end
-            end
-
-          end
-        end -- for i = 1, #cnn do
-
-        cnn = nil
-        collectgarbage()
-        
-        print(net)
-        
-        print('content_layers: ')
-        for i = 1, #content_layers do
-          print(content_layers[i])
-        end
-
-        print('mrf_layers: ')
-        for i = 1, #mrf_layers do
-          print(mrf_layers[i])
-        end
-
-        print('network has been built.')
-      else
-        input_image = image.scale(input_image:float(), pyramid_source_image_caffe[i_res]:size()[3], pyramid_source_image_caffe[i_res]:size()[2], 'bilinear'):clone()
-        if params.backend == 'cudnn' then
-          input_image = input_image:cuda()
-        else
-          input_image = input_image:cl()
-        end
-
-        -- -- update content layers
-        for i_layer = 1, #content_layers do
-          update_content(content_layers[i_layer], i_layer)
-          -- print(string.format('content_layers %d has been updated', content_layers[i_layer]))
-        end
-
-      end
-
-      print('*****************************************************')
-      print('Synthesis started at resolution ' .. cur_res)
-      print('*****************************************************')
-
-      print('Implementing mrf layers ...')
-      for i = 1, #mrf_layers do
-        if build_mrf(i) == false then
-          print('build_mrf failed')
-          do return end
-        end
-      end
-
-      mask = torch.Tensor(input_image:size()):fill(1)
-      if params.backend == 'cudnn' then
-        mask = mask:cuda()
-      else
-        mask = mask:cl()
-      end
-
-      y = net:forward(input_image)              
-      dy = input_image.new(#y):zero()
-
-      -- do optimizatoin
-      local x, losses = mylbfgs(feval, input_image, optim_state, nil, mask) 
-
-      local t = timer:time().real
-      print('Synthesis finished at resolution ' .. cur_res ..  ', ' .. t .. ' seconds')
-    end
-
-  net = nil
-  source_image = nil
-  target_image = nil
-  pyramid_source_image_caffe = nil
-  pyramid_target_image_caffe = nil
-  input_image = nil
-  output_image = nil
-  content_losses = nil
-  content_layers = nil
-  mrf_losses = nil
-  mrf_layers = nil
-  optim_state = nil
-  collectgarbage()  
-  collectgarbage()
-      
-  end -- end of main
-
-
-
-  function preprocess(img)
-    local mean_pixel = torch.Tensor({103.939, 116.779, 123.68})
-    local perm = torch.LongTensor{3, 2, 1}
-    img = img:index(1, perm):mul(256.0)
-    mean_pixel = mean_pixel:view(3, 1, 1):expandAs(img)
-    img:add(-1, mean_pixel)
-    return img
-  end
-
-  -- Undo the above preprocessing.
-  function deprocess(img)
-    local mean_pixel = torch.Tensor({103.939, 116.779, 123.68})
-    mean_pixel = mean_pixel:view(3, 1, 1):expandAs(img)
-    img = img + mean_pixel:float()
-    local perm = torch.LongTensor{3, 2, 1}
-    img = img:index(1, perm):div(256.0)
-    return img
-  end
-  
   main(params)
 
   local t_test = timer_TEST:time().real
-  print('Total time:  ' .. t_test .. 'seconds.') 
+  print(string.format('Total time: %f seconds', t_test))
   -- sleep(1)
   return flag_state
 end
 
 return {
-  state = run_test
+  run_test = run_test,
+  main = main
 }


### PR DESCRIPTION
I added bunch of stuff around the project that should not really affect the inner functionality.
- cmd line arguments declared in cnnmrf.lua file and I kept the original scripts run_syn and run_trans so you still can call parameters in batches
- replaced .. operator with better string.format
- replaced original table unfolding through indexing in run_ scripts to easier table.unpack
- extracted preprocess and deprocess methods up to helper.lua as they are called from both wrappers
- changed few global variables that were not used globally to local

Maybe it would be a good idea to rewrite readme a bit and include parameter descriptions+those reference tests
